### PR TITLE
Chat Auto Coder 插件系统

### DIFF
--- a/src/autocoder/chat_auto_coder.py
+++ b/src/autocoder/chat_auto_coder.py
@@ -1,5 +1,3 @@
-
-
 import argparse
 import os
 from prompt_toolkit import PromptSession
@@ -10,13 +8,15 @@ from prompt_toolkit.styles import Style
 from autocoder.version import __version__
 from autocoder.chat_auto_coder_lang import get_message
 from prompt_toolkit.formatted_text import FormattedText
+from prompt_toolkit.completion import Completer, Completion
+from autocoder.plugins import PluginManager
 from autocoder.auto_coder_runner import (
     auto_command,
     load_memory,
     save_memory,
-    configure,    
+    configure,
     manage_models,
-    print_conf,    
+    print_conf,
     exclude_dirs,
     exclude_files,
     ask,
@@ -35,23 +35,36 @@ from autocoder.auto_coder_runner import (
     mcp,
     revert,
     commit,
-    design,    
+    design,
     voice_input,
     chat,
     gen_and_exec_shell_command,
     execute_shell_command,
     get_mcp_server,
     completer,
-    summon,  
-    get_memory  
+    summon,
+    get_memory,
 )
 
+# Create a global plugin manager
+plugin_manager = PluginManager()
+
+# Create wrapped versions of intercepted functions
+original_functions = {
+    "ask": ask,
+    "coding": coding,
+    "chat": chat,
+    "design": design,
+    "voice_input": voice_input,
+    "auto_command": auto_command,
+    "execute_shell_command": execute_shell_command,
+}
+
+
 def parse_arguments():
-    
 
     parser = argparse.ArgumentParser(description="Chat Auto Coder")
-    parser.add_argument("--debug", action="store_true",
-                        help="Enable debug mode")
+    parser.add_argument("--debug", action="store_true", help="Enable debug mode")
     parser.add_argument(
         "--quick",
         action="store_true",
@@ -103,10 +116,8 @@ def show_help():
     print(
         f"  \033[94m/summon\033[0m \033[93m<query>\033[0m - \033[92m{get_message('summon_desc')}\033[0m"
     )
-    print(
-        f"  \033[94m/revert\033[0m - \033[92m{get_message('revert_desc')}\033[0m")
-    print(
-        f"  \033[94m/commit\033[0m - \033[92m{get_message('commit_desc')}\033[0m")
+    print(f"  \033[94m/revert\033[0m - \033[92m{get_message('revert_desc')}\033[0m")
+    print(f"  \033[94m/commit\033[0m - \033[92m{get_message('commit_desc')}\033[0m")
     print(
         f"  \033[94m/conf\033[0m \033[93m<key>:<value>\033[0m  - \033[92m{get_message('conf_desc')}\033[0m"
     )
@@ -119,8 +130,7 @@ def show_help():
     print(
         f"  \033[94m/list_files\033[0m - \033[92m{get_message('list_files_desc')}\033[0m"
     )
-    print(
-        f"  \033[94m/help\033[0m - \033[92m{get_message('help_desc')}\033[0m")
+    print(f"  \033[94m/help\033[0m - \033[92m{get_message('help_desc')}\033[0m")
     print(
         f"  \033[94m/exclude_dirs\033[0m \033[93m<dir1>,<dir2> ...\033[0m - \033[92m{get_message('exclude_dirs_desc')}\033[0m"
     )
@@ -130,13 +140,119 @@ def show_help():
     print(
         f"  \033[94m/voice_input\033[0m - \033[92m{get_message('voice_input_desc')}\033[0m"
     )
-    print(
-        f"  \033[94m/mode\033[0m - \033[92m{get_message('mode_desc')}\033[0m")
+    print(f"  \033[94m/mode\033[0m - \033[92m{get_message('mode_desc')}\033[0m")
     print(f"  \033[94m/lib\033[0m - \033[92m{get_message('lib_desc')}\033[0m")
     print(f"  \033[94m/models\033[0m - \033[92m{get_message('models_desc')}\033[0m")
-    print(
-        f"  \033[94m/exit\033[0m - \033[92m{get_message('exit_desc')}\033[0m")
+    print(f"  \033[94m/plugins\033[0m - \033[92m{get_message('plugins_desc')}\033[0m")
+    print(f"  \033[94m/exit\033[0m - \033[92m{get_message('exit_desc')}\033[0m")
     print()
+
+    # 显示插件命令
+    if plugin_manager.command_handlers:
+        print("\033[1mPlugin Commands:\033[0m")
+        print("  \033[94mCommand\033[0m - \033[93mDescription\033[0m")
+        for cmd, (_, desc, plugin_id) in plugin_manager.command_handlers.items():
+            plugin = plugin_manager.get_plugin(plugin_id)
+            print(
+                f"  \033[94m{cmd}\033[0m - \033[92m{desc} (from {plugin.plugin_name()})\033[0m"
+            )
+        print()
+
+
+class EnhancedCompleter(Completer):
+    """结合内置补全器和插件补全功能的增强补全器"""
+
+    def __init__(self, base_completer: Completer, plugin_manager: PluginManager):
+        self.base_completer: Completer = base_completer
+        self.plugin_manager: PluginManager = plugin_manager
+
+    def get_completions(self, document, complete_event):
+        # 获取当前输入的文本
+        text_before_cursor = document.text_before_cursor.lstrip()
+
+        # 只有当我们需要处理命令补全时才进行处理
+        if text_before_cursor.startswith("/"):
+
+            # 获取当前输入的命令前缀
+            current_input = text_before_cursor
+            # 检查是否需要动态补全
+            if " " in current_input:
+                # 将连续的空格替换为单个空格
+                _input_one_space = " ".join(current_input.split())
+                # 先尝试动态补全特定命令
+                dynamic_cmds = self.plugin_manager.get_dynamic_cmds()
+                for dynamic_cmd in dynamic_cmds:
+                    if _input_one_space.startswith(dynamic_cmd):
+                        # 使用 PluginManager 处理动态补全，通常是用于命令或子命令动态的参数值列表的补全
+                        completions = self.plugin_manager.process_dynamic_completions(
+                            dynamic_cmd, current_input
+                        )
+                        for completion_text, display_text in completions:
+                            yield Completion(
+                                completion_text,
+                                start_position=0,
+                                display=display_text,
+                            )
+                        return
+
+                # 如果不是特定命令，检查一般命令 + 空格的情况, 通常是用于固定的下级子命令列表的补全
+                cmd_parts = current_input.split(maxsplit=1)
+                base_cmd = cmd_parts[0]
+
+                # 获取插件命令补全
+                plugin_completions_dict = self.plugin_manager.get_plugin_completions()
+
+                # 如果命令存在于补全字典中，进行处理
+                if base_cmd in plugin_completions_dict:
+                    yield from self._process_command_completions(
+                        base_cmd, current_input, plugin_completions_dict[base_cmd]
+                    )
+                    return
+            # 处理直接命令补全 - 如果输入不包含空格，匹配整个命令
+            for command in self.plugin_manager.get_all_commands_with_prefix(current_input):
+                yield Completion(
+                    command[len(current_input) :],
+                    start_position=0,
+                    display=command,
+                )
+
+        # 获取并返回基础补全器的补全
+        if self.base_completer:
+            for completion in self.base_completer.get_completions(
+                document, complete_event
+            ):
+                yield completion
+
+    def _process_command_completions(self, command, current_input, completions):
+        """处理通用命令补全"""
+        # 提取子命令前缀
+        parts = current_input.split(maxsplit=1)
+        cmd_prefix = ""
+        if len(parts) > 1:
+            cmd_prefix = parts[1].strip()
+
+        # 对于任何命令，当子命令前缀为空或与补全选项匹配时，都显示补全
+        for completion in completions:
+            if cmd_prefix == "" or completion.startswith(cmd_prefix):
+                # 只提供未输入部分作为补全
+                remaining_text = completion[len(cmd_prefix) :]
+                # 修复：设置 start_position 为 0，这样不会覆盖用户已输入的部分
+                start_position = 0
+                yield Completion(
+                    remaining_text,
+                    start_position=start_position,
+                    display=completion,
+                )
+
+    async def get_completions_async(self, document, complete_event):
+        """异步获取补全内容。
+
+        这个方法在最新版本的prompt_toolkit中是必需的，
+        它简单地调用同步版本并以异步方式yield结果。
+        """
+        for completion in self.get_completions(document, complete_event):
+            yield completion
+
 
 ARGS = None
 
@@ -150,20 +266,30 @@ def main():
         ARGS.product_mode = "lite"
 
     if ARGS.pro:
-        ARGS.product_mode = "pro" 
+        ARGS.product_mode = "pro"
 
-    if not ARGS.quick:        
-        initialize_system(InitializeSystemRequest(
-            product_mode=ARGS.product_mode,
-            skip_provider_selection=ARGS.skip_provider_selection,
-            debug=ARGS.debug,
-            quick=ARGS.quick,
-            lite=ARGS.lite,
-            pro=ARGS.pro
-        ))
+    if not ARGS.quick:
+        initialize_system(
+            InitializeSystemRequest(
+                product_mode=ARGS.product_mode,
+                skip_provider_selection=ARGS.skip_provider_selection,
+                debug=ARGS.debug,
+                quick=ARGS.quick,
+                lite=ARGS.lite,
+                pro=ARGS.pro,
+            )
+        )
+
+    # Initialize plugin system
+    # Add default plugin directory into global plugin dirs
+    plugin_manager.load_global_plugin_dirs()
+    plugin_manager.add_global_plugin_directory(os.path.join(os.path.dirname(__file__), "plugins"))
+
+    # 加载保存的运行时配置
+    plugin_manager.load_runtime_cfg()
 
     load_memory()
-    memory = get_memory()    
+    memory = get_memory()
 
     configure(f"product_mode:{ARGS.product_mode}")
 
@@ -218,6 +344,9 @@ def main():
         configure(f"human_as_model:{new_status}", skip_print=True)
         event.app.invalidate()
 
+    # 应用插件的键盘绑定
+    plugin_manager.apply_keybindings(kb)
+
     def get_bottom_toolbar():
         if "mode" not in memory:
             memory["mode"] = "auto_detect"
@@ -225,17 +354,25 @@ def main():
         human_as_model = memory["conf"].get("human_as_model", "false")
         if mode not in MODES:
             mode = "auto_detect"
-        pwd = os.getcwd()    
+        pwd = os.getcwd()
         pwd_parts = pwd.split(os.sep)
         if len(pwd_parts) > 3:
             pwd = os.sep.join(pwd_parts[-3:])
-        return f"Current Dir: {pwd} \nMode: {MODES[mode]}(ctrl+k) | Human as Model: {human_as_model}(ctrl+n) "
+
+        # Add plugin information to toolbar
+        plugin_info = (
+            f"Plugins: {len(plugin_manager.plugins)}" if plugin_manager.plugins else ""
+        )
+        return f"Current Dir: {pwd} \nMode: {MODES[mode]}(ctrl+k) | Human as Model: {human_as_model}(ctrl+n) | {plugin_info}"
+
+    # 创建一个继承Completer的增强补全器
+    enhanced_completer = EnhancedCompleter(completer, plugin_manager)
 
     session = PromptSession(
         history=InMemoryHistory(),
         auto_suggest=AutoSuggestFromHistory(),
         enable_history_search=False,
-        completer=completer,
+        completer=enhanced_completer,
         complete_while_typing=True,
         key_bindings=kb,
         bottom_toolbar=get_bottom_toolbar,
@@ -251,6 +388,14 @@ def main():
     \033[0m"""
     )
     print("\033[1;34mType /help to see available commands.\033[0m\n")
+
+    # Add plugin information to startup message
+    if plugin_manager.plugins:
+        print("\033[1;34mLoaded Plugins:\033[0m")
+        for name, plugin in plugin_manager.plugins.items():
+            print(f"  - {name} (v{plugin.version}): {plugin.description}")
+        print()
+
     show_help()
 
     style = Style.from_dict(
@@ -264,6 +409,25 @@ def main():
     )
 
     new_prompt = ""
+
+    # Create wrapped versions of functions that plugins want to intercept
+    wrapped_functions = {}
+    for func_name, original_func in original_functions.items():
+        wrapped_functions[func_name] = plugin_manager.wrap_function(
+            original_func, func_name
+        )
+
+    # Replace original functions with wrapped versions
+    global ask, coding, chat, design, voice_input, auto_command, execute_shell_command
+    ask = wrapped_functions.get("ask", ask)
+    coding = wrapped_functions.get("coding", coding)
+    chat = wrapped_functions.get("chat", chat)
+    design = wrapped_functions.get("design", design)
+    voice_input = wrapped_functions.get("voice_input", voice_input)
+    auto_command = wrapped_functions.get("auto_command", auto_command)
+    execute_shell_command = wrapped_functions.get(
+        "execute_shell_command", execute_shell_command
+    )
 
     while True:
         try:
@@ -281,8 +445,7 @@ def main():
                     FormattedText(prompt_message), default=new_prompt, style=style
                 )
             else:
-                user_input = session.prompt(
-                    FormattedText(prompt_message), style=style)
+                user_input = session.prompt(FormattedText(prompt_message), style=style)
             new_prompt = ""
 
             if "mode" not in memory:
@@ -291,78 +454,96 @@ def main():
             # 处理 user_input 的空格
             if user_input:
                 temp_user_input = user_input.lstrip()  # 去掉左侧空格
-                if temp_user_input.startswith('/'):
+                if temp_user_input.startswith("/"):
                     user_input = temp_user_input
 
-            if (  
-                memory["mode"] == "auto_detect" 
+            # Check if this is a plugin command
+            if user_input.startswith("/"):
+                plugin_result = plugin_manager.process_command(user_input)
+                if plugin_result:
+                    plugin_name, handler, args = plugin_result
+                    if handler:
+                        handler(*args)
+                        continue
+
+            if (
+                memory["mode"] == "auto_detect"
                 and user_input
                 and not user_input.startswith("/")
             ):
-                auto_command(ARGS,user_input)
+                auto_command(ARGS, user_input)
 
             elif memory["mode"] == "voice_input" and not user_input.startswith("/"):
                 text = voice_input()
-                new_prompt = "/coding " + text
+                if text:  # Check if text is not None
+                    new_prompt = "/coding " + text
 
             elif user_input.startswith("/voice_input"):
                 text = voice_input()
-                new_prompt = "/coding " + text
+                if text:  # Check if text is not None
+                    new_prompt = "/coding " + text
 
             elif user_input.startswith("/clear") or user_input.startswith("/cls"):
                 print("\033c")                
 
             elif user_input.startswith("/add_files"):
-                args = user_input[len("/add_files"):].strip().split()
+                args = user_input[len("/add_files") :].strip().split()
                 add_files(args)
             elif user_input.startswith("/remove_files"):
-                file_names = user_input[len(
-                    "/remove_files"):].strip().split(",")
+                file_names = user_input[len("/remove_files") :].strip().split(",")
                 remove_files(file_names)
             elif user_input.startswith("/index/query"):
-                query = user_input[len("/index/query"):].strip()
+                query = user_input[len("/index/query") :].strip()
                 index_query(query)
 
             elif user_input.startswith("/index/build"):
                 index_build()
 
             elif user_input.startswith("/index/export"):
-                export_path = user_input[len("/index/export"):].strip()
-                index_export(export_path)                    
+                export_path = user_input[len("/index/export") :].strip()
+                index_export(export_path)
 
             elif user_input.startswith("/index/import"):
-                import_path  = user_input[len("/index/import"):].strip()
-                index_import(import_path)                    
+                import_path = user_input[len("/index/import") :].strip()
+                index_import(import_path)
 
             elif user_input.startswith("/list_files"):
                 list_files()
 
             elif user_input.startswith("/models"):
-                query = user_input[len("/models"):].strip()
+                query = user_input[len("/models") :].strip()
                 if not query:
                     print("Please enter your query.")
                 else:
-                    manage_models(query) 
+                    manage_models(query)
 
             elif user_input.startswith("/mode"):
-                conf = user_input[len("/mode"):].strip()
+                conf = user_input[len("/mode") :].strip()
                 if not conf:
                     print(memory["mode"])
                 else:
-                    memory["mode"] = conf                    
-            
+                    memory["mode"] = conf
+
             elif user_input.startswith("/conf/export"):
                 from autocoder.common.conf_import_export import export_conf
-                export_path = user_input[len("/conf/export"):].strip()
-                export_conf(os.getcwd(), export_path)                    
-            
+
+                export_path = user_input[len("/conf/export") :].strip()
+                export_conf(os.getcwd(), export_path)
+
             elif user_input.startswith("/conf/import"):
                 from autocoder.common.conf_import_export import import_conf
-                import_path = user_input[len("/conf/import"):].strip()
-                import_conf(os.getcwd(), import_path)                    
-                    
+
+                import_path = user_input[len("/conf/import") :].strip()
+                import_conf(os.getcwd(), import_path)
+
+            elif user_input.startswith("/plugins"):
+                # 提取命令参数并交由 plugin_manager 处理
+                args = user_input[len("/plugins") :].strip().split()
+                result = plugin_manager.handle_plugins_command(args)
+                print(result, end="")
+
             elif user_input.startswith("/conf"):
-                conf = user_input[len("/conf"):].strip()
+                conf = user_input[len("/conf") :].strip()
                 if not conf:
                     print_conf(memory["conf"])
                 else:
@@ -370,26 +551,25 @@ def main():
             elif user_input.startswith("/revert"):
                 revert()
             elif user_input.startswith("/commit"):
-                query = user_input[len("/commit"):].strip()
+                query = user_input[len("/commit") :].strip()
                 commit(query)
             elif user_input.startswith("/help"):
-                query = user_input[len("/help"):].strip()
+                query = user_input[len("/help") :].strip()
                 if not query:
                     show_help()
                 else:
                     help(query)
 
             elif user_input.startswith("/exclude_dirs"):
-                dir_names = user_input[len(
-                    "/exclude_dirs"):].strip().split(",")
+                dir_names = user_input[len("/exclude_dirs") :].strip().split(",")
                 exclude_dirs(dir_names)
 
             elif user_input.startswith("/exclude_files"):
-                query = user_input[len("/exclude_files"):].strip()                
+                query = user_input[len("/exclude_files") :].strip()
                 exclude_files(query)
 
             elif user_input.startswith("/ask"):
-                query = user_input[len("/ask"):].strip()
+                query = user_input[len("/ask") :].strip()
                 if not query:
                     print("Please enter your question.")
                 else:
@@ -399,64 +579,64 @@ def main():
                 raise EOFError()
 
             elif user_input.startswith("/coding"):
-                query = user_input[len("/coding"):].strip()
+                query = user_input[len("/coding") :].strip()
                 if not query:
                     print("\033[91mPlease enter your request.\033[0m")
                     continue
                 coding(query)
             elif user_input.startswith("/chat"):
-                query = user_input[len("/chat"):].strip()
+                query = user_input[len("/chat") :].strip()
                 if not query:
                     print("\033[91mPlease enter your request.\033[0m")
                 else:
                     chat(query)
 
             elif user_input.startswith("/design"):
-                query = user_input[len("/design"):].strip()
+                query = user_input[len("/design") :].strip()
                 if not query:
                     print("\033[91mPlease enter your design request.\033[0m")
                 else:
                     design(query)
 
             elif user_input.startswith("/summon"):
-                query = user_input[len("/summon"):].strip()
+                query = user_input[len("/summon") :].strip()
                 if not query:
                     print("\033[91mPlease enter your request.\033[0m")
                 else:
                     summon(query)
 
             elif user_input.startswith("/lib"):
-                args = user_input[len("/lib"):].strip().split()
+                args = user_input[len("/lib") :].strip().split()
                 lib_command(args)
 
             elif user_input.startswith("/mcp"):
-                query = user_input[len("/mcp"):].strip()
+                query = user_input[len("/mcp") :].strip()
                 if not query:
                     print("Please enter your query.")
                 else:
                     mcp(query)
 
             elif user_input.startswith("/auto"):
-                query = user_input[len("/auto"):].strip()
-                auto_command(ARGS,query)
+                query = user_input[len("/auto") :].strip()
+                auto_command(ARGS, query)
             elif user_input.startswith("/debug"):
-                code = user_input[len("/debug"):].strip()
+                code = user_input[len("/debug") :].strip()
                 try:
                     result = eval(code)
                     print(f"Debug result: {result}")
                 except Exception as e:
-                    print(f"Debug error: {str(e)}")            
+                    print(f"Debug error: {str(e)}")
 
             # elif user_input.startswith("/shell"):
             else:
                 command = user_input
-                if user_input.startswith("/shell"):                    
-                    command = user_input[len("/shell"):].strip()
+                if user_input.startswith("/shell"):
+                    command = user_input[len("/shell") :].strip()
                     if not command:
                         print("Please enter a shell command to execute.")
                     else:
                         if command.startswith("/chat"):
-                            command = command[len("/chat"):].strip()
+                            command = command[len("/chat") :].strip()
                             gen_and_exec_shell_command(command)
                         else:
                             execute_shell_command(command)
@@ -465,6 +645,9 @@ def main():
             continue
         except EOFError:
             try:
+                # Shutdown all plugins before exiting
+                plugin_manager.shutdown_all()
+
                 save_memory()
                 try:
                     if get_mcp_server():

--- a/src/autocoder/chat_auto_coder_lang.py
+++ b/src/autocoder/chat_auto_coder_lang.py
@@ -131,16 +131,18 @@ MESSAGES = {
         "files_removed": "Files Removed",
         "models_api_key_empty": "Warning : {{name}} API key is empty. Please set a valid API key.",
         "commit_generating": "{{ model_name }} Generating commit message...",
-        "auto_command_reasoning_title": "Reply", 
+        "auto_command_reasoning_title": "Reply",
         "commit_message": "{{ model_name }} Generated commit message: {{ message }}",
         "commit_failed": "{{ model_name }} Failed to generate commit message: {{ error }}",
         "confirm_execute": "Do you want to execute this script?",
         "official_doc": "Official Documentation: https://uelng8wukz.feishu.cn/wiki/NhPNwSRcWimKFIkQINIckloBncI",
+        "plugins_desc": "Manage plugins",
+        "plugins_usage": "Usage: /plugins <command>\nAvailable subcommands:\n  /plugins /list - List all available plugins\n  /plugins /load <name> - Load a plugin\n  /plugins /unload <name> - Unload a plugin\n  /plugins/dirs - List plugin directories\n  /plugins/dirs /add <path> - Add a plugin directory\n  /plugins/dirs /remove <path> - Remove a plugin directory\n  /plugins/dirs /clear - Clear all plugin directories",
     },
     "zh": {
         "auto_command_analyzing": "正在分析命令请求",
         "commit_generating": "{{ model_name }} 正在生成提交信息...",
-        "auto_command_reasoning_title": "回复", 
+        "auto_command_reasoning_title": "回复",
         "commit_message": "{{ model_name }} 生成的提交信息: {{ message }}",
         "commit_failed": "{{ model_name }} 生成提交信息失败: {{ error }}",
         "mcp_remove_error": "移除 MCP 服务器时出错:{error}",
@@ -271,7 +273,9 @@ MESSAGES = {
         "models_api_key_empty": "警告:  {{name}}  API key 为空。请设置一个有效的 API key。",
         "confirm_execute": "是否执行此脚本?",
         "official_doc": "官方文档: https://uelng8wukz.feishu.cn/wiki/NhPNwSRcWimKFIkQINIckloBncI",
-    }
+        "plugins_desc": "管理插件",
+        "plugins_usage": "用法: /plugins <命令>\n可用的子命令:\n  /plugins /list - 列出所有可用插件\n  /plugins /load <名称> - 加载一个插件\n  /plugins /unload <名称> - 卸载一个插件\n  /plugins/dirs - 列出插件目录\n  /plugins/dirs /add <路径> - 添加一个插件目录\n  /plugins/dirs /remove <路径> - 移除一个插件目录\n  /plugins/dirs /clear - 清除所有插件目录",
+    },
 }
 
 
@@ -279,12 +283,12 @@ def get_system_language():
     try:
         return locale.getdefaultlocale()[0][:2]
     except:
-        return 'en'
+        return "en"
 
 
 def get_message(key):
     lang = get_system_language()
-    return MESSAGES.get(lang, MESSAGES['en']).get(key, MESSAGES['en'][key])
+    return MESSAGES.get(lang, MESSAGES["en"]).get(key, MESSAGES["en"][key])
 
 
 def get_message_with_format(msg_key: str, **kwargs):

--- a/src/autocoder/plugins/README.md
+++ b/src/autocoder/plugins/README.md
@@ -13,19 +13,7 @@ This directory contains the plugin system for Chat Auto Coder, which allows exte
 
 ## Using Plugins
 
-You can load plugins in several ways:
-
-1. Command line arguments:
-   ```
-   python -m autocoder.chat_auto_coder --plugin_dirs /path/to/plugins --plugins PluginClass1,PluginClass2
-   ```
-
-2. Configuration file:
-   ```
-   python -m autocoder.chat_auto_coder --plugin_config /path/to/config.json
-   ```
-
-3. At runtime using the `/plugins` command:
+At runtime using the `/plugins` command:
    ```
    /plugins list              # List available plugins
    /plugins load PluginClass  # Load a specific plugin

--- a/src/autocoder/plugins/README.md
+++ b/src/autocoder/plugins/README.md
@@ -1,0 +1,250 @@
+# Chat Auto Coder Plugin System
+
+This directory contains the plugin system for Chat Auto Coder, which allows extending the functionality of the application at runtime.
+
+## Plugin System Features
+
+- Add new commands to the Chat Auto Coder
+- Intercept and modify existing commands
+- Intercept and modify function calls
+- Add custom keybindings
+- Provide command completions
+- No-invasive architecture (doesn't require modifying existing code)
+
+## Using Plugins
+
+You can load plugins in several ways:
+
+1. Command line arguments:
+   ```
+   python -m autocoder.chat_auto_coder --plugin_dirs /path/to/plugins --plugins PluginClass1,PluginClass2
+   ```
+
+2. Configuration file:
+   ```
+   python -m autocoder.chat_auto_coder --plugin_config /path/to/config.json
+   ```
+
+3. At runtime using the `/plugins` command:
+   ```
+   /plugins list              # List available plugins
+   /plugins load PluginClass  # Load a specific plugin
+   /plugins unload PluginName # Unload a plugin
+   /plugins                   # Show loaded plugins
+   ```
+
+## Plugin Directories
+
+Chat Auto Coder supports two types of plugin directories:
+
+1. **Project-specific plugin directories**: Only available in the current project.
+2. **Global plugin directories**: Available across all projects for the current user.
+
+### Managing Plugin Directories
+
+You can manage plugin directories using the `/plugins/dirs` command:
+
+```
+/plugins/dirs                # List all plugin directories (both global and project-specific)
+/plugins/dirs /add <path>    # Add a project-specific plugin directory
+/plugins/dirs /remove <path> # Remove a project-specific plugin directory
+/plugins/dirs /clear         # Clear all project-specific plugin directories
+```
+
+Global plugin directories are stored in `~/.auto-coder/plugins/global_plugin_dirs` and are automatically loaded when Chat Auto Coder starts. They remain available across all your projects.
+
+To add a global plugin directory, you'll need to edit the global plugin directories file directly, or use the API from code.
+
+## Creating Plugins
+
+To create a plugin, subclass the `Plugin` class from `autocoder.plugins`:
+
+```python
+from autocoder.plugins import Plugin
+
+class MyPlugin(Plugin):
+    name = "my_plugin"
+    description = "My custom plugin"
+    version = "0.1.0"
+    
+    def __init__(self, manager, config=None, config_path=None):
+        super().__init__(manager, config, config_path)
+        # Initialize your plugin
+    
+    def initialize(self):
+        # This method is for plugin self-initialization
+        # You can set up resources, register event handlers, or perform any startup tasks
+        # The register_function_interception below is just an example of what you might do here
+        self.manager.register_function_interception(self.name, "ask")
+        return True
+    
+    def get_commands(self):
+        return {
+            "my_command": (self.my_command_handler, "My custom command"),
+        }
+    
+    def my_command_handler(self, args):
+        print(f"My command executed with: {args}")
+    
+    def get_keybindings(self):
+        return [
+            ("c-m", self.my_keybinding_handler, "My custom keybinding"),
+        ]
+    
+    def my_keybinding_handler(self, event):
+        print("My keybinding pressed!")
+    
+    def intercept_command(self, command, args):
+        # Return True, command, args to allow normal processing
+        # Return False, new_command, new_args to take over processing
+        return True, command, args
+    
+    def intercept_function(self, func_name, args, kwargs):
+        # Modify args or kwargs if needed
+        return True, args, kwargs
+    
+    def post_function(self, func_name, result):
+        # Modify result if needed
+        return result
+    
+    def export_config(self, config_path=None):
+        # Export plugin configuration for persistence
+        # Return None if no configuration is needed
+        return self.config
+    
+    def shutdown(self):
+        # Clean up resources
+        pass
+```
+
+## Plugin Configuration
+
+Plugins can be configured using a JSON file. Example:
+
+```json
+{
+    "plugin_dirs": [
+        "src/autocoder/plugins",
+        "user_plugins"
+    ],
+    "plugins": [
+        "autocoder.plugins.sample_plugin.SamplePlugin",
+        "user_plugins.my_plugin.MyPlugin"
+    ]
+}
+```
+
+The configuration for each plugin is stored separately in the project's `.auto-coder/plugins/{plugin_id}/config.json` directory. The plugin manager takes care of loading and saving these configurations.
+
+Global plugin directories are stored in `~/.auto-coder/plugins/global_plugin_dirs` and are automatically loaded for all projects.
+
+## Built-in Plugins
+
+The following plugins are included with Chat Auto Coder:
+
+- `SamplePlugin`: A demonstration plugin showing basic functionality
+- `DynamicCompletionExamplePlugin`: A plugin demonstrating dynamic command completion functionality
+- `GitHelperPlugin`: A git command plugin
+
+
+## Plugin Identification
+
+Each plugin is uniquely identified by its full module and class name through the `id_name()` class method:
+
+```python
+@classmethod
+def id_name(cls) -> str:
+    """Return the unique identifier for the plugin including module path"""
+    return f"{cls.__module__}.{cls.__name__}"
+```
+
+This identifier is used for plugin registration, loading, and configuration management.
+
+## Plugin API Reference
+
+### Plugin Class
+
+Base class for all plugins:
+
+- `name`: Plugin name (string)
+- `description`: Plugin description (string)
+- `version`: Plugin version (string)
+- `dynamic_cmds`: List of commands that require dynamic completion (list of strings). This list specifies which commands should use dynamic completion based on the current context. For example, a plugin might set this to `["/my_command"]` to indicate that `/my_command` should have dynamic completions.
+- `initialize()`: Called when the plugin is loaded. Used for plugin self-initialization such as setting up resources, connecting to services, or any other startup tasks. Return `True` if initialization is successful, `False` otherwise.
+- `get_commands()`: Returns a dictionary of commands provided by the plugin
+- `get_keybindings()`: Returns a list of keybindings provided by the plugin
+- `get_completions()`: Returns a dictionary of command completions
+- `get_dynamic_completions(command, current_input)`: Returns dynamic completions based on input context
+- `intercept_command(command, args)`: Intercept and potentially modify commands
+- `intercept_function(func_name, args, kwargs)`: Intercept and potentially modify function calls
+- `post_function(func_name, result)`: Process function results
+- `export_config(config_path)`: Export plugin configuration
+- `shutdown()`: Called when the plugin is unloaded or the application is exiting
+
+### PluginManager Class
+
+Manages plugins for the Chat Auto Coder:
+
+- `add_plugin_directory(directory)`: Add a directory to search for plugins (project-specific)
+- `add_global_plugin_directory(directory)`: Add a global directory to search for plugins (available in all projects)
+- `remove_plugin_directory(directory)`: Remove a project-specific plugin directory
+- `clear_plugin_directories()`: Clear all project-specific plugin directories
+- `load_global_plugin_dirs()`: Load global plugin directories from ~/.auto-coder/plugins/global_plugin_dirs
+- `save_global_plugin_dirs()`: Save global plugin directories to ~/.auto-coder/plugins/global_plugin_dirs
+- `discover_plugins()`: Discover available plugins in plugin directories
+- `load_plugin(plugin_class, config)`: Load and initialize a plugin
+- `load_plugins_from_config(config)`: Load plugins based on configuration
+- `get_plugin(name)`: Get a plugin by name
+- `process_command(full_command)`: Process a command, allowing plugins to intercept it
+- `wrap_function(original_func, func_name)`: Wrap a function to allow plugin interception
+- `register_function_interception(plugin_name, func_name)`: Register a plugin's interest in intercepting a function
+- `get_all_commands()`: Get all commands from all plugins
+- `get_plugin_completions()`: Get command completions from all plugins
+- `get_dynamic_completions(command, current_input)`: Get dynamic completions based on current input
+- `load_runtime_cfg()`: Load runtime configuration for plugins
+- `save_runtime_cfg()`: Save runtime configuration for plugins
+- `shutdown_all()`: Shutdown all plugins
+
+### Module-Level Functions
+
+The `autocoder.plugins` module also provides the following functions:
+
+- `register_global_plugin_dir(directory)`: Register a directory as a global plugin directory during plugin installation. This is a convenience function for plugin installation scripts.
+
+## Plugin Installation and Registration
+
+When creating installation scripts for plugins, you can use the `register_global_plugin_dir` module-level function to automatically register your plugin's directory as a global plugin directory. This makes the plugin available to all projects on the user's machine.
+
+### Example: Plugin Installation Script
+
+```python
+#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+def install_plugin():
+    """Install the plugin and register it globally."""
+    # Get the current directory (where your plugin code is located)
+    plugin_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    try:
+        # Import the plugin manager module
+        sys.path.insert(0, str(Path(plugin_dir).parent))
+        from autocoder.plugins import register_global_plugin_dir
+        
+        # Register the plugin directory globally using the module function
+        register_global_plugin_dir(plugin_dir)
+        print(f"✅ Successfully registered plugin directory: {plugin_dir}")
+        print(f"The plugin is now available in all Chat Auto Coder projects.")
+            
+        return True
+    except Exception as e:
+        print(f"❌ Error during plugin installation: {str(e)}")
+        return False
+
+if __name__ == "__main__":
+    if install_plugin():
+        print("Installation completed successfully!")
+    else:
+        print("Installation failed. Please check the error messages above.") 

--- a/src/autocoder/plugins/README.md
+++ b/src/autocoder/plugins/README.md
@@ -107,21 +107,6 @@ class MyPlugin(Plugin):
 
 ## Plugin Configuration
 
-Plugins can be configured using a JSON file. Example:
-
-```json
-{
-    "plugin_dirs": [
-        "src/autocoder/plugins",
-        "user_plugins"
-    ],
-    "plugins": [
-        "autocoder.plugins.sample_plugin.SamplePlugin",
-        "user_plugins.my_plugin.MyPlugin"
-    ]
-}
-```
-
 The configuration for each plugin is stored separately in the project's `.auto-coder/plugins/{plugin_id}/config.json` directory. The plugin manager takes care of loading and saving these configurations.
 
 Global plugin directories are stored in `~/.auto-coder/plugins/global_plugin_dirs` and are automatically loaded for all projects.

--- a/src/autocoder/plugins/README_zh.md
+++ b/src/autocoder/plugins/README_zh.md
@@ -13,19 +13,7 @@
 
 ## 使用插件
 
-您可以通过以下几种方式加载插件：
-
-1. 命令行参数：
-   ```
-   python -m autocoder.chat_auto_coder --plugin_dirs /path/to/plugins --plugins PluginClass1,PluginClass2
-   ```
-
-2. 配置文件：
-   ```
-   python -m autocoder.chat_auto_coder --plugin_config /path/to/config.json
-   ```
-
-3. 在运行时使用 `/plugins` 命令：
+在运行时使用 `/plugins` 命令：
    ```
    /plugins list              # 列出可用插件
    /plugins load PluginClass  # 加载特定插件

--- a/src/autocoder/plugins/README_zh.md
+++ b/src/autocoder/plugins/README_zh.md
@@ -1,0 +1,250 @@
+# Chat Auto Coder 插件系统
+
+本目录包含 Chat Auto Coder 的插件系统，允许在运行时扩展应用程序的功能。
+
+## 插件系统特性
+
+- 向 Chat Auto Coder 添加新命令
+- 拦截和修改现有命令
+- 拦截和修改函数调用
+- 添加自定义键绑定
+- 提供命令补全功能
+- 非侵入式架构（不需要修改现有代码）
+
+## 使用插件
+
+您可以通过以下几种方式加载插件：
+
+1. 命令行参数：
+   ```
+   python -m autocoder.chat_auto_coder --plugin_dirs /path/to/plugins --plugins PluginClass1,PluginClass2
+   ```
+
+2. 配置文件：
+   ```
+   python -m autocoder.chat_auto_coder --plugin_config /path/to/config.json
+   ```
+
+3. 在运行时使用 `/plugins` 命令：
+   ```
+   /plugins list              # 列出可用插件
+   /plugins load PluginClass  # 加载特定插件
+   /plugins unload PluginName # 卸载插件
+   /plugins                   # 显示已加载插件
+   ```
+
+## 插件目录
+
+Chat Auto Coder 支持两种类型的插件目录：
+
+1. **项目特定插件目录**：仅在当前项目中可用。
+2. **全局插件目录**：对当前用户的所有项目都可用。
+
+### 管理插件目录
+
+您可以使用 `/plugins/dirs` 命令管理插件目录：
+
+```
+/plugins/dirs                # 列出所有插件目录（全局和项目特定）
+/plugins/dirs /add <path>    # 添加项目特定插件目录
+/plugins/dirs /remove <path> # 删除项目特定插件目录
+/plugins/dirs /clear         # 清除所有项目特定插件目录
+```
+
+全局插件目录存储在 `~/.auto-coder/plugins/global_plugin_dirs` 文件中，并在 Chat Auto Coder 启动时自动加载。它们在所有项目中保持可用。
+
+要添加全局插件目录，您需要直接编辑全局插件目录文件，或使用代码中的API。
+
+## 创建插件
+
+要创建插件，需要继承 `autocoder.plugins` 中的 `Plugin` 类：
+
+```python
+from autocoder.plugins import Plugin
+
+class MyPlugin(Plugin):
+    name = "my_plugin"
+    description = "我的自定义插件"
+    version = "0.1.0"
+    
+    def __init__(self, manager, config=None, config_path=None):
+        super().__init__(manager, config, config_path)
+        # 初始化您的插件
+    
+    def initialize(self):
+        # 此方法用于插件自身的初始化
+        # 您可以在这里设置资源、注册事件处理程序或执行任何启动任务
+        # 下面的register_function_interception只是一个示例，说明您可能在这里做什么
+        self.manager.register_function_interception(self.name, "ask")
+        return True
+    
+    def get_commands(self):
+        return {
+            "my_command": (self.my_command_handler, "我的自定义命令"),
+        }
+    
+    def my_command_handler(self, args):
+        print(f"我的命令已执行，参数: {args}")
+    
+    def get_keybindings(self):
+        return [
+            ("c-m", self.my_keybinding_handler, "我的自定义按键绑定"),
+        ]
+    
+    def my_keybinding_handler(self, event):
+        print("我的按键被按下！")
+    
+    def intercept_command(self, command, args):
+        # 返回 True, command, args 允许正常处理
+        # 返回 False, new_command, new_args 接管处理
+        return True, command, args
+    
+    def intercept_function(self, func_name, args, kwargs):
+        # 根据需要修改 args 或 kwargs
+        return True, args, kwargs
+    
+    def post_function(self, func_name, result):
+        # 根据需要修改结果
+        return result
+    
+    def export_config(self, config_path=None):
+        # 导出插件配置用于持久化存储
+        # 如果不需要配置，返回 None
+        return self.config
+    
+    def shutdown(self):
+        # 清理资源
+        pass
+```
+
+## 插件配置
+
+插件可以使用 JSON 文件进行配置。示例：
+
+```json
+{
+    "plugin_dirs": [
+        "src/autocoder/plugins",
+        "user_plugins"
+    ],
+    "plugins": [
+        "autocoder.plugins.sample_plugin.SamplePlugin",
+        "user_plugins.my_plugin.MyPlugin"
+    ]
+}
+```
+
+每个插件的配置单独存储在项目的 `.auto-coder/plugins/{plugin_id}/config.json` 目录中。插件管理器负责加载和保存这些配置。
+
+全局插件目录存储在 `~/.auto-coder/plugins/global_plugin_dirs` 文件中，并对所有项目自动加载。
+
+## 内置插件
+
+Chat Auto Coder 包含以下插件：
+
+- `SamplePlugin`：演示基本功能的示例插件
+- `DynamicCompletionExamplePlugin`：演示动态命令补全功能的插件
+- `GitHelperPlugin`：Git 命令插件
+
+
+## 插件标识
+
+每个插件通过 `id_name()` 类方法获取完整的模块和类名作为唯一标识符：
+
+```python
+@classmethod
+def id_name(cls) -> str:
+    """返回插件的唯一标识符，包括模块路径"""
+    return f"{cls.__module__}.{cls.__name__}"
+```
+
+此标识符用于插件注册、加载和配置管理。
+
+## 插件 API 参考
+
+### Plugin 类
+
+所有插件的基类：
+
+- `name`：插件名称（字符串）
+- `description`：插件描述（字符串）
+- `version`：插件版本（字符串）
+- `dynamic_cmds`：需要动态补全的命令列表（字符串列表）。此列表指定哪些命令应该根据当前上下文使用动态补全。例如，插件可以将其设置为 `["/my_command"]` 来表示 `/my_command` 应该有动态补全。
+- `initialize()`：插件加载时调用。用于插件自身初始化，例如设置资源、连接服务或任何其他启动任务。初始化成功返回`True`，否则返回`False`。
+- `get_commands()`：返回插件提供的命令字典
+- `get_keybindings()`：返回插件提供的按键绑定列表
+- `get_completions()`：返回命令补全字典
+- `get_dynamic_completions(command, current_input)`：根据输入上下文返回动态补全选项
+- `intercept_command(command, args)`：拦截并可能修改命令
+- `intercept_function(func_name, args, kwargs)`：拦截并可能修改函数调用
+- `post_function(func_name, result)`：处理函数结果
+- `export_config(config_path)`：导出插件配置
+- `shutdown()`：插件卸载或应用程序退出时调用
+
+### PluginManager 类
+
+管理 Chat Auto Coder 的插件：
+
+- `add_plugin_directory(directory)`：添加用于搜索插件的目录（项目特定）
+- `add_global_plugin_directory(directory)`：添加用于搜索插件的全局目录（对所有项目可用）
+- `remove_plugin_directory(directory)`：删除项目特定插件目录
+- `clear_plugin_directories()`：清除所有项目特定插件目录
+- `load_global_plugin_dirs()`：从 ~/.auto-coder/plugins/global_plugin_dirs 加载全局插件目录
+- `save_global_plugin_dirs()`：保存全局插件目录到 ~/.auto-coder/plugins/global_plugin_dirs
+- `discover_plugins()`：在插件目录中发现可用插件
+- `load_plugin(plugin_class, config)`：加载并初始化插件
+- `load_plugins_from_config(config)`：基于配置加载插件
+- `get_plugin(name)`：通过名称获取插件
+- `process_command(full_command)`：处理命令，允许插件拦截
+- `wrap_function(original_func, func_name)`：包装函数以允许插件拦截
+- `register_function_interception(plugin_name, func_name)`：注册插件对拦截函数的兴趣
+- `get_all_commands()`：获取所有插件的所有命令
+- `get_plugin_completions()`：获取所有插件的命令补全
+- `get_dynamic_completions(command, current_input)`：根据当前输入获取动态补全选项
+- `load_runtime_cfg()`：加载插件的运行时配置
+- `save_runtime_cfg()`：保存插件的运行时配置
+- `shutdown_all()`：关闭所有插件
+
+### 模块级别函数
+
+`autocoder.plugins` 模块还提供以下函数：
+
+- `register_global_plugin_dir(directory)`：在插件安装过程中将目录注册为全局插件目录。这是为插件安装脚本提供的便捷函数。
+
+## 插件安装与注册
+
+在创建插件安装脚本时，您可以使用 `register_global_plugin_dir` 模块级别函数自动将插件目录注册为全局插件目录。这使得插件对用户机器上的所有项目都可用。
+
+### 示例：插件安装脚本
+
+```python
+#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+def install_plugin():
+    """安装插件并全局注册。"""
+    # 获取当前目录（插件代码所在位置）
+    plugin_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    try:
+        # 导入插件管理器模块
+        sys.path.insert(0, str(Path(plugin_dir).parent))
+        from autocoder.plugins import register_global_plugin_dir
+        
+        # 使用模块函数将插件目录全局注册
+        register_global_plugin_dir(plugin_dir)
+        print(f"✅ 成功注册插件目录：{plugin_dir}")
+        print(f"该插件现在可用于所有 Chat Auto Coder 项目。")
+            
+        return True
+    except Exception as e:
+        print(f"❌ 插件安装过程中出错：{str(e)}")
+        return False
+
+if __name__ == "__main__":
+    if install_plugin():
+        print("安装成功完成！")
+    else:
+        print("安装失败。请查看上面的错误信息。") 

--- a/src/autocoder/plugins/README_zh.md
+++ b/src/autocoder/plugins/README_zh.md
@@ -107,21 +107,6 @@ class MyPlugin(Plugin):
 
 ## 插件配置
 
-插件可以使用 JSON 文件进行配置。示例：
-
-```json
-{
-    "plugin_dirs": [
-        "src/autocoder/plugins",
-        "user_plugins"
-    ],
-    "plugins": [
-        "autocoder.plugins.sample_plugin.SamplePlugin",
-        "user_plugins.my_plugin.MyPlugin"
-    ]
-}
-```
-
 每个插件的配置单独存储在项目的 `.auto-coder/plugins/{plugin_id}/config.json` 目录中。插件管理器负责加载和保存这些配置。
 
 全局插件目录存储在 `~/.auto-coder/plugins/global_plugin_dirs` 文件中，并对所有项目自动加载。

--- a/src/autocoder/plugins/__init__.py
+++ b/src/autocoder/plugins/__init__.py
@@ -1,0 +1,1123 @@
+"""
+Plugin system for Chat Auto Coder.
+This module provides the base classes and functionality for creating and managing plugins.
+"""
+
+import importlib
+import inspect
+import os
+import sys
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
+from autocoder.plugins.utils import load_json_file, save_json_file
+
+
+class Plugin:
+    """Base class for all plugins."""
+
+    name: str = "base_plugin"  # 插件名称
+    description: str = "Base plugin class"  # 插件描述
+    version: str = "0.1.0"  # 插件版本
+    manager: "PluginManager"  # 插件管理器
+    dynamic_cmds: List[str] = []  # 需要动态补全的命令列表
+
+    @classmethod
+    def id_name(cls) -> str:
+        """返回插件的唯一标识符，包括插件目录和插件文件名"""
+        return f"{cls.__module__}.{cls.__name__}"
+
+    @classmethod
+    def plugin_name(cls) -> str:
+        """返回插件的名称，不包括插件目录和插件文件名"""
+        return cls.__name__
+
+    def __init__(
+        self,
+        manager: "PluginManager",
+        config: Optional[Dict[str, Any]] = None,
+        config_path: Optional[str] = None,
+    ):
+        """Initialize the plugin.
+
+        Args:
+            manager: The plugin manager instance
+            config: Optional configuration dictionary for the plugin
+            config_path: Optional path to the configuration file
+        """
+        self.config = config or {}
+        self.config_path = config_path
+        self.manager = manager
+
+    def initialize(self) -> bool:
+        """Initialize the plugin.
+
+        This method is called after the plugin instance is created but before
+        it is registered with the plugin manager. Override this method to
+        perform any initialization tasks.
+
+        Returns:
+            True if initialization was successful, False otherwise
+        """
+        return True
+
+    def get_commands(self) -> Dict[str, Tuple[Callable, str]]:
+        """Get the commands provided by this plugin.
+
+        Returns:
+            A dictionary mapping command names to (handler, description) tuples
+        """
+        return {}
+
+    def get_keybindings(self) -> List[Tuple[str, Callable, str]]:
+        """Get the keybindings provided by this plugin.
+
+        Returns:
+            A list of (key_combination, handler, description) tuples
+        """
+        return []
+
+    def get_completions(self) -> Dict[str, List[str]]:
+        """Get the completions provided by this plugin.
+
+        Returns:
+            A dictionary mapping command prefixes to lists of completion options
+        """
+        return {}
+
+    def load_config(self, config_path: Optional[str] = None) -> bool:
+        """加载插件配置。
+
+        Args:
+            config_path: 配置文件路径。如果提供，将覆盖插件的 config_path 属性。
+
+        Returns:
+            加载成功返回 True，否则返回 False
+        """
+        # 如果提供了新的配置路径，则更新 self.config_path
+        if config_path:
+            self.config_path = config_path
+
+        # 如果没有配置路径，则无法加载
+        if not self.config_path:
+            return False
+
+        # 尝试从文件加载配置
+        try:
+            import json
+            import os
+
+            if os.path.exists(self.config_path):
+                with open(self.config_path, "r", encoding="utf-8") as f:
+                    self.config = json.load(f)
+                return True
+            else:
+                # 配置文件不存在，但路径有效，视为成功
+                return True
+        except Exception as e:
+            print(f"Error loading plugin config from {self.config_path}: {e}")
+            return False
+
+    def export_config(
+        self, config_path: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """导出插件配置，用于持久化存储。
+
+        默认实现会返回插件的 self.config 属性，并将配置保存到 self.config_path 或提供的 config_path。
+        子类可以覆盖此方法，以提供自定义的配置导出逻辑。
+
+        Args:
+            config_path: 配置文件保存路径。如果提供，将覆盖插件的 config_path 属性。
+
+        Returns:
+            包含插件配置的字典，如果没有配置需要导出则返回 None
+        """
+        # 如果没有配置，则返回 None
+        if not self.config:
+            return None
+
+        # 更新配置路径（如果提供）
+        if config_path:
+            self.config_path = config_path
+
+        # 通过插件管理器获取插件配置路径
+        config_path = self.manager.get_plugin_config_path(self.id_name())
+        if config_path:
+            self.config_path = config_path
+
+        # 如果有配置路径，则保存至文件
+        if self.config_path:
+            try:
+                import json
+                import os
+
+                # 确保目录存在
+                os.makedirs(
+                    os.path.dirname(os.path.abspath(self.config_path)), exist_ok=True
+                )
+
+                # 保存配置到文件
+                with open(self.config_path, "w", encoding="utf-8") as f:
+                    json.dump(self.config, f, indent=2, ensure_ascii=False)
+            except Exception as e:
+                print(f"Error saving plugin config to {self.config_path}: {e}")
+
+        return self.config
+
+    def get_dynamic_completions(
+        self, command: str, current_input: str
+    ) -> List[Tuple[str, str]]:
+        """Get dynamic completions based on the current command context.
+
+        This method provides context-aware completions for commands that need
+        dynamic options based on the current state or user input.
+
+        Args:
+            command: The base command (e.g., "/example select")
+            current_input: The full current input including the command
+
+        Returns:
+            A list of tuples containing (completion_text, display_text)
+        """
+        return []
+
+    def intercept_command(
+        self, command: str, args: str
+    ) -> Tuple[bool, Optional[str], Optional[str]]:
+        """Intercept a command before it's processed.
+
+        Args:
+            command: The command name (without the /)
+            args: The command arguments
+
+        Returns:
+            A tuple of (should_continue, modified_command, modified_args)
+            If should_continue is False, the original command processing will be skipped
+        """
+        return True, command, args
+
+    def intercept_function(
+        self, func_name: str, args: List[Any], kwargs: Dict[str, Any]
+    ) -> Tuple[bool, List[Any], Dict[str, Any]]:
+        """Intercept a function call before it's executed.
+
+        Args:
+            func_name: The name of the function
+            args: The positional arguments
+            kwargs: The keyword arguments
+
+        Returns:
+            A tuple of (should_continue, modified_args, modified_kwargs)
+            If should_continue is False, the original function call will be skipped
+        """
+        return True, args, kwargs
+
+    def post_function(self, func_name: str, result: Any) -> Any:
+        """Process a function result after it's executed.
+
+        Args:
+            func_name: The name of the function
+            result: The result of the function call
+
+        Returns:
+            The possibly modified result
+        """
+        return result
+
+    def shutdown(self) -> None:
+        """Shutdown the plugin. Called when the application is exiting."""
+        pass
+
+
+class PluginManager:
+    """Manages plugins for the Chat Auto Coder."""
+
+    def __init__(self):
+        """Initialize the plugin manager."""
+        self.plugins: Dict[str, Plugin] = {}
+        self.command_handlers: Dict[str, Tuple[Callable, str, str]] = (
+            {}
+        )  # command -> (handler, description, plugin_name)
+        self.intercepted_functions: Dict[str, List[str]] = (
+            {}
+        )  # function_name -> [plugin_names]
+        self.global_plugin_dirs: List[str] = []
+        self.plugin_dirs: List[str] = []
+        self._discover_plugins_cache: List[Type[Plugin]] = None  # type: ignore
+
+        # built-in commands
+        self._builtin_commands = [
+            "/plugins",
+            "/plugins/dirs",
+        ]
+        # 内置的动态命令列表
+        self._builtin_dynamic_cmds = [
+            "/plugins /load",
+            "/plugins /unload",
+            "/plugins/dirs /add",
+            "/plugins/dirs /remove",
+            "/plugins/dirs /clear",
+        ]
+
+    @property
+    def cached_discover_plugins(self) -> List[Type[Plugin]]:
+        if self._discover_plugins_cache is None:
+            self._discover_plugins_cache = self.discover_plugins()
+        return self._discover_plugins_cache
+
+    def load_global_plugin_dirs(self) -> None:
+        """Read global plugin dirs from ~/.auto-coder/plugins/global_plugin_dirs"""
+        global_plugin_dirs_path = os.path.expanduser("~/.auto-coder/plugins/global_plugin_dirs")
+        if os.path.exists(global_plugin_dirs_path):
+            with open(global_plugin_dirs_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    ok, msg = self.add_global_plugin_directory(line.strip())
+                    if not ok:
+                        print(f"🚫 Error adding global plugin directory: {msg}")
+
+    def save_global_plugin_dirs(self) -> None:
+        """Save global plugin dirs to ~/.auto-coder/plugins/global_plugin_dirs"""
+        global_plugin_dirs_path = os.path.expanduser("~/.auto-coder/plugins/global_plugin_dirs")
+        # 确保目录存在
+        os.makedirs(os.path.dirname(global_plugin_dirs_path), exist_ok=True)
+        with open(global_plugin_dirs_path, "w", encoding="utf-8") as f:
+            for plugin_dir in self.global_plugin_dirs:
+                f.write(plugin_dir + "\n")
+        print(f"Saved global plugin dirs to {global_plugin_dirs_path}")
+
+    def add_global_plugin_directory(self, directory: str) -> Tuple[bool, str]:
+        """Add a directory to search for plugins.
+
+        Args:
+            directory: The directory path
+
+        Returns:
+            Tuple of (success: bool, message: str)
+        """
+        normalized_dir = os.path.abspath(os.path.normpath(directory))
+        if os.path.isdir(normalized_dir):
+            if normalized_dir not in self.global_plugin_dirs:
+                self.global_plugin_dirs.append(normalized_dir)
+                if normalized_dir not in sys.path:
+                    sys.path.append(normalized_dir)
+                self._discover_plugins_cache = None  # type: ignore
+                self.save_global_plugin_dirs()
+            return True, f"Added global directory: {normalized_dir}"
+        return False, f"Invalid directory: {normalized_dir}"
+
+    def add_plugin_directory(self, directory: str) -> Tuple[bool, str]:
+        """Add a directory to search for plugins.
+
+        Args:
+            directory: The directory path
+
+        Returns:
+            Tuple of (success: bool, message: str)
+        """
+        normalized_dir = os.path.abspath(os.path.normpath(directory))
+        if os.path.isdir(normalized_dir):
+            if normalized_dir not in self.plugin_dirs and normalized_dir not in self.global_plugin_dirs:
+                self.plugin_dirs.append(normalized_dir)
+                if normalized_dir not in sys.path:
+                    sys.path.append(normalized_dir)
+                self._discover_plugins_cache = None  # type: ignore
+                return True, f"Added directory: {normalized_dir}"
+            return False, f"Directory already exists: {normalized_dir}"
+        return False, f"Invalid directory: {normalized_dir}"
+
+    def remove_plugin_directory(self, directory: str) -> str:
+        """Remove a plugin directory.
+
+        Args:
+            directory: The directory path to remove
+
+        Returns:
+            Result message
+        """
+        normalized_dir = os.path.normpath(directory)
+        if normalized_dir in self.plugin_dirs:
+            self.plugin_dirs.remove(normalized_dir)
+            if normalized_dir in sys.path:
+                sys.path.remove(normalized_dir)
+            self._discover_plugins_cache = None  # type: ignore
+            return f"Removed directory: {normalized_dir}"
+        return f"Directory not found: {normalized_dir}"
+
+    def clear_plugin_directories(self) -> str:
+        """Clear all plugin directories.
+
+        Returns:
+            Result message
+        """
+        count = len(self.plugin_dirs)
+        for directory in self.plugin_dirs:
+            if directory in sys.path:
+                sys.path.remove(directory)
+        self.plugin_dirs.clear()
+        self._discover_plugins_cache = None  # type: ignore
+        return f"Cleared all directories ({count} removed)"
+
+    def discover_plugins(self) -> List[Type[Plugin]]:
+        """Discover available plugins in the plugin directories.
+
+        Returns:
+            A list of plugin classes
+        """
+        discovered_plugins: List[Type[Plugin]] = []
+
+        plugin_dirs = set(self.plugin_dirs)
+        plugin_dirs.update(self.global_plugin_dirs)
+
+        for plugin_dir in plugin_dirs:
+            for filename in os.listdir(plugin_dir):
+                if filename.endswith(".py") and not filename.startswith("_"):
+                    module_name = filename[:-3]
+                    try:
+                        # Fully qualify module name with path information
+                        plugin_dir_basename = os.path.basename(plugin_dir)
+                        parent_dir = os.path.basename(os.path.dirname(plugin_dir))
+
+                        if (
+                            parent_dir == "autocoder"
+                            and plugin_dir_basename == "plugins"
+                        ):
+                            # For built-in plugins
+                            full_module_name = f"autocoder.plugins.{module_name}"
+                        else:
+                            # For external plugins
+                            full_module_name = module_name
+
+                        # Try to import using the determined module name
+                        try:
+                            module = importlib.import_module(full_module_name)
+                        except ImportError:
+                            # Fallback to direct module name
+                            module = importlib.import_module(module_name)
+
+                        for name, obj in inspect.getmembers(module):
+                            if (
+                                inspect.isclass(obj)
+                                and issubclass(obj, Plugin)
+                                and obj is not Plugin
+                            ):
+                                discovered_plugins.append(obj)
+                    except Exception as e:
+                        print(f"Error loading plugin module {module_name}: {e}")
+
+        return discovered_plugins
+
+    def load_plugin(
+        self, plugin_class: Type[Plugin], config: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        """Load and initialize a plugin.
+
+        Args:
+            plugin_class: The plugin class to load
+            config: Optional configuration for the plugin
+
+        Returns:
+            True if the plugin was loaded successfully, False otherwise
+        """
+        try:
+            # 获取插件名称和插件ID
+            # plugin_name = plugin_class.plugin_name()
+            plugin_id = plugin_class.id_name()
+
+            # 获取插件配置路径
+            config_path = self.get_plugin_config_path(plugin_id)
+
+            # 创建插件实例，传入 manager(self) 作为第一个参数
+            plugin = plugin_class(self, config, config_path)
+
+            # 如果未提供配置但配置路径存在，尝试加载配置
+            if not config and config_path:
+                plugin.load_config()
+
+            # 调用插件的 initialize 方法，只有成功初始化的插件才会被添加
+            if not plugin.initialize():
+                print(f"Plugin {plugin_id} initialization failed")
+                return False
+
+            # 将插件添加到已加载插件字典中
+            self.plugins[plugin_id] = plugin
+
+            # Register commands
+            for cmd, (handler, desc) in plugin.get_commands().items():
+                self.command_handlers[f"/{cmd}"] = (handler, desc, plugin_id)
+
+            return True
+        except Exception as e:
+            print(f"Error loading plugin {plugin_class.__name__}: {e}")
+            return False
+
+    def load_plugins_from_config(self, config: Dict[str, Any]) -> None:
+        """Load plugins based on configuration.
+
+        Args:
+            config: Configuration dictionary with plugin settings
+        """
+        if "plugin_dirs" in config:
+            for directory in config["plugin_dirs"]:
+                self.add_plugin_directory(directory)
+
+        if "plugins" in config:
+            discovered_plugins = {p.id_name(): p for p in self.cached_discover_plugins}
+
+            for plugin_id in config["plugins"]:
+                if plugin_id in discovered_plugins:
+                    self.load_plugin(discovered_plugins[plugin_id])
+
+    def get_plugin(self, name: str) -> Optional[Plugin]:
+        """Get a plugin by name or full class name.
+
+        Args:
+            name: The name or full class name of the plugin
+
+        Returns:
+            The plugin instance, or None if not found
+        """
+        # 直接通过全类名查找 (优先), name 是 plugin_id
+        if name in self.plugins:
+            return self.plugins[name]
+
+        # 如果没找到，尝试通过简单名称查找
+        for plugin in self.plugins.values():
+            if plugin.plugin_name() == name or plugin.name == name:
+                return plugin
+
+        return None
+
+    def process_command(
+        self, full_command: str
+    ) -> Optional[Tuple[str, Optional[Callable], List[str]]]:
+        """Process a command, allowing plugins to intercept it.
+
+        Args:
+            full_command: The full command string including the /
+
+        Returns:
+            A tuple of (plugin_name, handler, args) if a plugin should handle the command,
+            None if it should be handled by the main program
+        """
+        if not full_command.startswith("/"):
+            return None
+
+        parts = full_command.split(maxsplit=1)
+        command = parts[0]
+        args = parts[1] if len(parts) > 1 else ""
+
+        # Check if any plugin wants to intercept this command
+        command_without_slash = command[1:] if command.startswith("/") else command
+
+        for plugin_name, plugin in self.plugins.items():
+            should_continue, modified_command, modified_args = plugin.intercept_command(
+                command_without_slash, args
+            )
+            if not should_continue:
+                if modified_command and modified_command in self.command_handlers:
+                    handler, _, handler_plugin = self.command_handlers[modified_command]
+                    return (
+                        handler_plugin,
+                        handler,
+                        [modified_args] if modified_args is not None else [""],
+                    )
+                return plugin_name, None, [modified_command or "", modified_args or ""]
+
+        # Check if this is a registered plugin command
+        if command in self.command_handlers:
+            handler, _, plugin_name = self.command_handlers[command]
+            return plugin_name, handler, [args]
+
+        return None
+
+    def wrap_function(self, original_func: Callable, func_name: str) -> Callable:
+        """Wrap a function to allow plugins to intercept it.
+
+        Args:
+            original_func: The original function
+            func_name: The name of the function
+
+        Returns:
+            A wrapped function that allows plugin interception
+        """
+
+        def wrapped(*args, **kwargs):
+            # Pre-processing by plugins
+            should_continue = True
+            for plugin_name in self.intercepted_functions.get(func_name, []):
+                plugin = self.plugins[plugin_name]
+                plugin_continue, args, kwargs = plugin.intercept_function(
+                    func_name, list(args), kwargs
+                )
+                should_continue = should_continue and plugin_continue
+
+            # Execute the original function if no plugin cancelled it
+            if should_continue:
+                result = original_func(*args, **kwargs)
+
+                # Post-processing by plugins
+                for plugin_name in self.intercepted_functions.get(func_name, []):
+                    plugin = self.plugins[plugin_name]
+                    result = plugin.post_function(func_name, result)
+
+                return result
+            return None
+
+        return wrapped
+
+    def register_function_interception(self, plugin_name: str, func_name: str) -> None:
+        """Register a plugin's interest in intercepting a function.
+
+        Args:
+            plugin_name: The name of the plugin
+            func_name: The name of the function to intercept
+        """
+        if func_name not in self.intercepted_functions:
+            self.intercepted_functions[func_name] = []
+
+        if plugin_name not in self.intercepted_functions[func_name]:
+            self.intercepted_functions[func_name].append(plugin_name)
+
+    def get_all_commands(self) -> Dict[str, Tuple[str, str]]:
+        """Get all commands from all plugins.
+
+        Returns:
+            A dictionary mapping command names to (description, plugin_name) tuples
+        """
+        return {
+            cmd: (desc, plugin)
+            for cmd, (_, desc, plugin) in self.command_handlers.items()
+        }
+
+    def get_all_commands_with_prefix(self, prefix: str) :
+        """Get all commands from all plugins and built-in commands match the prefix.
+
+        Args:
+            prefix: The prefix to match
+
+        Returns:
+            A list of command names
+        """
+        # check prefix of built-in commands + plugin commands
+        for cmd in (self._builtin_commands + list(self.command_handlers.keys())):
+            if cmd.startswith(prefix):
+                yield cmd
+
+    def get_plugin_completions(self) -> Dict[str, List[str]]:
+        """Get command completions from all plugins.
+
+        Returns:
+            A dictionary mapping command prefixes to lists of completion options
+        """
+        completions = {
+            "/plugins": ["/list", "/load", "/unload"],
+            "/plugins/dirs": ["/add", "/remove", "/clear"],
+        }
+
+        # Get completions from plugins
+        for plugin in self.plugins.values():
+            plugin_completions = plugin.get_completions()
+            for prefix, options in plugin_completions.items():
+                if prefix not in completions:
+                    completions[prefix] = []
+                completions[prefix].extend(options)
+        return completions
+
+    def get_dynamic_completions(
+        self, command: str, current_input: str
+    ) -> List[Tuple[str, str]]:
+        """Get dynamic completions based on the current command context.
+
+        This method provides context-aware completions for commands that need
+        dynamic options based on the current state or user input.
+
+        Args:
+            command: The base command (e.g., "/plugins /load")
+            current_input: The full current input including the command
+
+        Returns:
+            A list of tuples containing (completion_text, display_text)
+        """
+        # print(f'command: {command}')
+
+        command = command.strip()
+        completions = self._get_manager_dynamic_completions(command, current_input)
+
+        # 检查是否有插件提供了此命令的动态补全
+        for plugin in self.plugins.values():
+            # 检查插件是否有 dynamic_completions
+            plugin_completions = plugin.get_dynamic_completions(command, current_input)
+            if plugin_completions:
+                completions.extend(plugin_completions)
+
+        return completions
+
+    def _get_manager_dynamic_completions(self, command: str, current_input: str) -> List[Tuple[str, str]]:
+        """获取插件管理器的动态补全。
+
+        Args:
+            command: 当前命令
+            current_input: 当前输入
+        """
+        # Split the input to analyze command parts
+        parts = current_input.split(maxsplit=2)
+        completions = []
+
+        # Handle built-in /plugins subcommands
+        if command == "/plugins /load":
+            # 提供可用插件列表作为补全选项
+            plugin_prefix = ""
+            if len(parts) > 2:
+                plugin_prefix = parts[2]
+
+            # 获取所有可用的插件
+            discovered_plugins = self.cached_discover_plugins
+
+            # 记录已经添加的显示名称，避免重复
+            added_display_names = set()
+
+            # 过滤出与前缀匹配的插件名称
+            for plugin_class in discovered_plugins:
+                plugin_name = plugin_class.name
+                plugin_class_name = plugin_class.plugin_name()
+                display_name = f"{plugin_class_name} ({plugin_name})"
+
+                # 首先尝试匹配插件短名称
+                if (
+                    plugin_name.startswith(plugin_prefix)
+                    and display_name not in added_display_names
+                ):
+                    completions.append((plugin_name, display_name))
+                    added_display_names.add(display_name)
+                # 如果类名与短名称不同，也尝试匹配类名
+                elif (
+                    plugin_class_name.startswith(plugin_prefix)
+                    and plugin_class_name != plugin_name
+                    and display_name not in added_display_names
+                ):
+                    completions.append((plugin_class_name, display_name))
+                    added_display_names.add(display_name)
+
+        elif command == "/plugins /unload":
+            # 提供已加载插件列表作为补全选项
+            plugin_prefix = ""
+            if len(parts) > 2:
+                plugin_prefix = parts[2]
+
+            # 记录已经添加的显示名称，避免重复
+            added_display_names = set()
+
+            # 获取所有已加载的插件
+            for plugin_id, plugin in self.plugins.items():
+                plugin_name = plugin.name
+                plugin_class_name = plugin.plugin_name()
+                display_name = f"{plugin_class_name} ({plugin_name})"
+
+                # 首先尝试匹配插件短名称
+                if (
+                    plugin_name.startswith(plugin_prefix)
+                    and display_name not in added_display_names
+                ):
+                    completions.append((plugin_name, display_name))
+                    added_display_names.add(display_name)
+                # 如果类名与短名称不同，也尝试匹配类名
+                elif (
+                    plugin_class_name.startswith(plugin_prefix)
+                    and plugin_class_name != plugin_name
+                    and display_name not in added_display_names
+                ):
+                    completions.append((plugin_class_name, display_name))
+                    added_display_names.add(display_name)
+
+        elif command == "/plugins/dirs /add":
+            # 如果没有前缀，从当前目录开始补全
+            prefix = ""
+            if len(parts) > 2:
+                prefix = " ".join(parts[2:])
+                prefix = prefix.strip()
+
+            # 获取搜索目标目录，如果 prefix 为空，则从当前目录开始搜索
+            target_dir = "."
+            if prefix:
+                target_dir = os.path.dirname(prefix)
+            # 获取文件名前缀
+            file_prefix = os.path.basename(prefix) if prefix else ""
+            # 如果父目录存在，列出其内容
+            if os.path.isdir(target_dir):
+                for entry in os.listdir(target_dir):
+                    full_path = os.path.join(target_dir, entry)
+                    if os.path.isdir(full_path) and entry.startswith(file_prefix):
+                        completions.append((full_path, entry))
+
+        elif command == "/plugins/dirs /remove":
+            # 如果没有前缀，显示所有插件目录
+            prefix = ""
+            if len(parts) > 3:
+                prefix = " ".join(parts[3:])
+
+            if not prefix:
+                for directory in self.plugin_dirs:
+                    completions.append((directory, directory))
+            else:
+                # 如果有前缀，过滤匹配的目录
+                for directory in self.plugin_dirs:
+                    if directory.startswith(prefix):
+                        # 如果目录以 prefix 开头，添加到补全列表
+                        completions.append((directory, directory))
+
+        return completions
+
+    def register_dynamic_completion_provider(
+        self, plugin_name: str, command_prefixes: List[str]
+    ) -> None:
+        """注册一个插件作为特定命令的动态补全提供者。
+
+        Args:
+            plugin_name: 插件名称
+            command_prefixes: 需要提供动态补全的命令前缀列表
+        """
+        # 此功能可以在未来拓展，例如维护一个映射
+        # 从命令前缀到能够提供其动态补全的插件
+        pass
+
+    def project_root(self) -> Optional[str]:
+        """检查当前是否在项目根目录。如果是,返回目录,否则返回None"""
+        current_dir = os.getcwd()
+        _root = os.path.join(current_dir, ".auto-coder")
+        if os.path.exists(_root):
+            return _root
+        return None
+
+    def load_runtime_cfg(self) -> None:
+        """从项目根目录加载运行时配置。
+
+        只加载插件目录和插件列表信息，具体配置由插件自行加载。
+        """
+        # 检查是否有项目根目录
+        project_root = self.project_root()
+        if not project_root:
+            return
+        # 加载插件列表和目录
+        plugins_json_path = os.path.join(project_root, "plugins.json")
+        if not os.path.exists(plugins_json_path):
+            return
+
+        try:
+            config = load_json_file(plugins_json_path)
+
+            # 添加插件目录
+            if "plugin_dirs" in config:
+                for directory in config["plugin_dirs"]:
+                    if os.path.isdir(directory):
+                        self.add_plugin_directory(directory)
+
+            # 加载插件 - 在 load_plugin 方法中会自动加载插件的配置
+            if "plugins" in config:
+                discovered_plugins = {
+                    p.id_name(): p for p in self.cached_discover_plugins
+                }
+
+                for plugin_id in config["plugins"]:
+                    if (
+                        plugin_id in discovered_plugins
+                        and plugin_id not in self.plugins
+                    ):
+                        # 加载插件 - 配置会在 load_plugin 方法中处理
+                        self.load_plugin(discovered_plugins[plugin_id])
+                # print(f"Successfully loaded plugins: {list(self.plugins.keys())}")
+        except Exception as e:
+            print(f"Error loading plugin configuration: {e}")
+
+    def save_runtime_cfg(self) -> None:
+        """将当前插件配置保存到运行时配置文件。
+
+        只保存插件目录和插件列表信息，具体配置由插件自行保存。
+        """
+        # 检查是否有项目根目录
+        project_root = self.project_root()
+        if not project_root:
+            return
+
+        # 保存插件目录和加载的插件列表
+        plugins_json_path = os.path.join(project_root, "plugins.json")
+        config = {"plugin_dirs": self.plugin_dirs, "plugins": list(self.plugins.keys())}
+
+        try:
+            # 仅当有插件配置变化时保存
+            for plugin in self.plugins.values():
+                plugin.export_config()
+            save_json_file(plugins_json_path, config)
+        except Exception as e:
+            print(f"Error saving plugins list: {e}")
+
+    def shutdown_all(self) -> None:
+        """Shutdown all plugins."""
+        # 保存配置
+        self.save_runtime_cfg()
+        if not self.plugins:
+            return
+        for plugin in self.plugins.values():
+            try:
+                plugin.shutdown()
+            except Exception as e:
+                print(f"Error shutting down plugin {plugin.name}: {e}")
+        print("All plugins shutdown")
+
+    def handle_plugins_command(self, args: List[str]) -> str:
+        """处理 /plugins 命令。
+
+        此方法处理插件的列出、加载和卸载等操作。
+
+        Args:
+            args: 命令参数列表，例如 ["list"]、["load", "plugin_name"] 等
+
+        Returns:
+            命令的输出结果
+        """
+        import io
+
+        output = io.StringIO()
+
+        if not args:
+            # 列出所有已加载的插件
+            print("\033[1;34mLoaded Plugins:\033[0m", file=output)
+            for plugin_id, plugin in self.plugins.items():
+                print(
+                    f"  - {plugin.name} (v{plugin.version}): {plugin.description}",
+                    file=output,
+                )
+
+        elif args[0] == "list":
+            # 列出所有可用的插件
+            discovered_plugins = self.discover_plugins()
+            print("\033[1;34mAvailable Plugins:\033[0m", file=output)
+            for plugin_class in discovered_plugins:
+                # 显示插件的短名称而不是完整ID
+                print(
+                    f"  - {plugin_class.plugin_name()} ({plugin_class.name}): {plugin_class.description}",
+                    file=output,
+                )
+
+        elif args[0] == "/list":
+            # 列出所有可用的插件
+            discovered_plugins = self.discover_plugins()
+            print("\033[1;34mAvailable Plugins:\033[0m", file=output)
+            for plugin_class in discovered_plugins:
+                # 显示插件的短名称而不是完整ID
+                print(
+                    f"  - {plugin_class.plugin_name()} ({plugin_class.name}): {plugin_class.description}",
+                    file=output,
+                )
+
+        elif args[0] == "load" or args[0] == "/load":
+            if len(args) <= 1:
+                print("Usage: /plugins /load <plugin_name>", file=output)
+                return output.getvalue()
+
+            # 加载特定的插件
+            plugin_name = args[1]
+            discovered_plugins = self.cached_discover_plugins
+
+            # 使用简短名称查找插件
+            found = False
+            for plugin_class in discovered_plugins:
+                if (
+                    plugin_class.plugin_name() == plugin_name
+                    or plugin_class.name == plugin_name
+                ):
+                    if self.load_plugin(plugin_class):
+                        print(
+                            f"Plugin '{plugin_name}' loaded successfully", file=output
+                        )
+                        # 加载插件后已在 load_plugin 方法中保存配置
+                    else:
+                        print(f"Failed to load plugin '{plugin_name}'", file=output)
+                    found = True
+                    break
+
+            if not found:
+                print(f"Plugin '{plugin_name}' not found", file=output)
+
+        elif args[0] == "unload" or args[0] == "/unload":
+            if len(args) <= 1:
+                print("Usage: /plugins /unload <plugin_name>", file=output)
+                return output.getvalue()
+
+            # 卸载特定的插件
+            plugin_name = args[1]
+            found = False
+
+            # 使用简短名称查找插件
+            for plugin_id, plugin in list(self.plugins.items()):
+                if plugin.plugin_name() == plugin_name or plugin.name == plugin_name:
+                    plugin = self.plugins.pop(plugin_id)
+                    plugin.shutdown()
+                    print(f"Plugin '{plugin_name}' unloaded", file=output)
+                    # 卸载插件后保存配置
+                    self.save_runtime_cfg()
+                    found = True
+                    break
+
+            if not found:
+                print(f"Plugin '{plugin_name}' not loaded", file=output)
+
+        elif args[0] == "dirs" or args[0] == "/dirs":
+            if len(args) < 2:
+                # 列出所有插件目录
+                print("\033[1;34mPlugin Directories:\033[0m", file=output)
+                # global plugin dirs
+                print("\033[33mGlobal Plugin Directories:\033[0m", file=output)
+                for idx, directory in enumerate(self.global_plugin_dirs, 1):
+                    status = (
+                        "\033[32m✓\033[0m"
+                        if os.path.exists(directory)
+                        else "\033[31m✗\033[0m"
+                    )
+                    print(f"  {idx}. {status} {directory}", file=output)
+                # project plugin dirs
+                print("\033[1;34mProject Plugin Directories:\033[0m", file=output)
+                for idx, directory in enumerate(self.plugin_dirs, 1):
+                    status = (
+                        "\033[32m✓\033[0m"
+                        if os.path.exists(directory)
+                        else "\033[31m✗\033[0m"
+                    )
+                    print(f"  {idx}. {status} {directory}", file=output)
+                return output.getvalue()
+
+            subcmd = args[1]
+            if (subcmd == "add" or subcmd == "/add") and len(args) > 2:
+                path = " ".join(args[2:])
+                success, msg = self.add_plugin_directory(path)
+                status = (
+                    "\033[32mSUCCESS\033[0m" if success else "\033[31mFAILED\033[0m"
+                )
+                print(f"{status}: {msg}", file=output)
+            elif (subcmd == "remove" or subcmd == "/remove") and len(args) > 2:
+                path = " ".join(args[2:])
+                msg = self.remove_plugin_directory(path)
+                print(f"\033[33m{msg}\033[0m", file=output)
+            elif subcmd == "clear" or subcmd == "/clear":
+                msg = self.clear_plugin_directories()
+                print(f"\033[33m{msg}\033[0m", file=output)
+            else:
+                print(
+                    "Usage: /plugins/dirs [/add <path>|/remove <path>|/clear]", file=output
+                )
+
+        else:
+            # 在找不到命令的情况下显示用法信息
+            print(
+                "Usage: /plugins [/list|/load <name>|/unload <name>|/dirs ...]", file=output
+            )
+
+        return output.getvalue()
+
+    def apply_keybindings(self, kb) -> None:
+        """将所有插件的键盘绑定应用到提供的键盘绑定器对象。
+
+        此方法迭代所有已加载的插件，获取它们的键盘绑定，并将这些绑定应用到键盘绑定器。
+        这样可以将键盘绑定的处理逻辑集中在 PluginManager 中，减少外部代码的耦合。
+
+        Args:
+            kb: 键盘绑定器对象，必须有一个 add 方法，该方法返回一个可调用对象用于注册处理程序
+        """
+        # 检查键盘绑定器是否有 add 方法
+        if not hasattr(kb, "add") or not callable(getattr(kb, "add")):
+            raise ValueError("键盘绑定器必须有一个可调用的 add 方法")
+
+        # 迭代所有插件
+        for plugin_key, plugin in self.plugins.items():
+            # 获取插件的键盘绑定
+            for key_combination, handler, description in plugin.get_keybindings():
+                # 应用键盘绑定
+                try:
+                    kb.add(key_combination)(handler)
+                except Exception as e:
+                    print(
+                        f"Error applying keybinding '{key_combination}' from plugin '{plugin_key}': {e}"
+                    )
+
+        return
+
+    def get_plugin_config_path(self, plugin_id: str) -> Optional[str]:
+        """获取插件配置文件的路径。
+
+        Args:
+            plugin_id: 插件的唯一标识符 (plugin.id_name())
+
+        Returns:
+            配置文件路径，如果项目根目录不存在则返回 None
+        """
+        # 检查是否有项目根目录
+        project_root = self.project_root()
+        if not project_root:
+            return None
+
+        # 创建配置目录和文件路径
+        config_dir = os.path.join(project_root, "plugins", plugin_id)
+        os.makedirs(config_dir, exist_ok=True)
+        return os.path.join(config_dir, "config.json")
+
+    def get_dynamic_cmds(self) -> List[str]:
+        """获取所有需要动态补全的命令列表。
+
+        包括内置的动态命令和所有插件提供的动态命令。
+
+        Returns:
+            需要动态补全的命令列表
+        """
+        dynamic_cmds = self._builtin_dynamic_cmds.copy()
+
+        # 收集所有插件提供的动态命令
+        for plugin in self.plugins.values():
+            if hasattr(plugin, "dynamic_cmds"):
+                dynamic_cmds.extend(plugin.dynamic_cmds)
+
+        return dynamic_cmds
+
+    def process_dynamic_completions(
+        self, command: str, current_input: str
+    ) -> List[Tuple[str, str]]:
+        """处理动态补全命令
+
+        Args:
+            command: 基础命令，如 /plugins
+            current_input: 当前完整的输入，如 /plugins/dirs /remove /usr
+
+        Returns:
+            List[Tuple[str, str]]: 补全选项列表，每个选项为 (补全文本, 显示文本)
+        """
+        # 获取动态补全选项
+        completions = self.get_dynamic_completions(command, current_input)
+
+        # 处理补全选项
+        processed_completions = []
+        parts = current_input.split()
+        existing_input = ""
+
+        # 如果输入包含子命令和参数
+        if len(parts) > 2:
+            # 获取最后一个部分作为补全前缀
+            existing_input = parts[-1]
+
+        # 只提供未输入部分作为补全
+        for completion_text, display_text in completions:
+            if completion_text.startswith(existing_input):
+                remaining_text = completion_text[len(existing_input) :]
+                processed_completions.append((remaining_text, display_text))
+
+        return processed_completions
+
+
+def register_global_plugin_dir(plugin_dir: str) -> None:
+    """注册一个全局插件目录。
+
+    Args:
+        plugin_dir: 插件目录路径
+    """
+    plugin_dir = os.path.abspath(os.path.normpath(plugin_dir))
+    if not os.path.exists(plugin_dir):
+        print(f"Plugin directory does not exist: {plugin_dir}")
+        return
+    plugin_manager = PluginManager()
+    plugin_manager.add_global_plugin_directory(plugin_dir)
+    print(f"Registered global plugin directory: {plugin_dir}")

--- a/src/autocoder/plugins/dynamic_completion_example.py
+++ b/src/autocoder/plugins/dynamic_completion_example.py
@@ -1,0 +1,148 @@
+"""
+Dynamic Completion Example Plugin for Chat Auto Coder.
+"""
+
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from autocoder.plugins import Plugin, PluginManager
+
+
+class DynamicCompletionExamplePlugin(Plugin):
+    """A sample plugin demonstrating dynamic completion functionality."""
+
+    name = "dynamic_completion_example"
+    description = "Demonstrates the dynamic completion feature"
+    version = "0.1.0"
+
+    def __init__(self, manager: PluginManager, config: Optional[Dict[str, Any]] = None, config_path: Optional[str] = None):
+        """Initialize the plugin.
+
+        Args:
+            manager: The plugin manager instance
+            config: Optional configuration dictionary for the plugin
+            config_path: Optional path to the configuration file
+        """
+        super().__init__(manager, config, config_path)
+        self.items = ["item1", "item2", "item3", "custom_item"]
+
+    def initialize(self) -> bool:
+        """Initialize the plugin.
+
+        Returns:
+            True if initialization was successful, False otherwise
+        """
+        # Register for function interception if needed
+        # self.manager.register_function_interception(self.name, "ask")
+
+        # Register as a dynamic completion provider
+        self.manager.register_dynamic_completion_provider(self.name, ["/example"])
+
+        return True
+
+    def get_commands(self) -> Dict[str, Tuple[Callable, str]]:
+        """Get commands provided by this plugin.
+
+        Returns:
+            A dictionary of command name to handler and description
+        """
+        return {
+            "example": (
+                self.example_command,
+                "Example command with dynamic completion",
+            ),
+            "example/add": (self.add_item, "Add a new item to the example list"),
+            "example/list": (self.list_items, "List all available items"),
+        }
+
+    def get_completions(self) -> Dict[str, List[str]]:
+        """Get completions provided by this plugin.
+
+        Returns:
+            A dictionary mapping command prefixes to completion options
+        """
+        # 基本的静态补全选项
+        return {
+            "/example": ["add", "list", "select"],
+        }
+
+    def get_dynamic_completions(
+        self, command: str, current_input: str
+    ) -> List[Tuple[str, str]]:
+        """Get dynamic completions based on the current command context.
+
+        Args:
+            command: The base command (e.g., "/example select")
+            current_input: The full current input including the command
+
+        Returns:
+            A list of tuples containing (completion_text, display_text)
+        """
+        # 如果是 /example select 命令，提供动态项目列表
+        if current_input.startswith("/example select"):
+            # 提取已输入的部分项目名
+            parts = current_input.split(maxsplit=2)
+            item_prefix = ""
+            if len(parts) > 2:
+                item_prefix = parts[2]
+
+            # 返回匹配的项目
+            return [
+                (item, f"{item} (example item)")
+                for item in self.items
+                if item.startswith(item_prefix)
+            ]
+
+        return []
+
+    def example_command(self, args: str) -> None:
+        """Handle the example command.
+
+        Args:
+            args: Command arguments
+        """
+        if not args:
+            print("Usage: /example [add|list|select]")
+            return
+
+        parts = args.split(maxsplit=1)
+        subcommand = parts[0]
+
+        if subcommand == "select" and len(parts) > 1:
+            item = parts[1]
+            if item in self.items:
+                print(f"Selected item: {item}")
+            else:
+                print(
+                    f"Item '{item}' not found. Use /example list to see available items."
+                )
+        else:
+            print(f"Unknown subcommand: {subcommand}. Use add, list, or select.")
+
+    def add_item(self, args: str) -> None:
+        """Add a new item to the list.
+
+        Args:
+            args: The item name to add
+        """
+        if not args:
+            print("Please specify an item name to add.")
+            return
+
+        if args in self.items:
+            print(f"Item '{args}' already exists.")
+        else:
+            self.items.append(args)
+            print(f"Added item: {args}")
+
+    def list_items(self, args: str) -> None:
+        """List all available items.
+
+        Args:
+            args: Ignored
+        """
+        print("Available items:")
+        for item in self.items:
+            print(f"  - {item}")
+
+    def shutdown(self) -> None:
+        """Shutdown the plugin."""
+        pass

--- a/src/autocoder/plugins/git_helper_plugin.py
+++ b/src/autocoder/plugins/git_helper_plugin.py
@@ -1,0 +1,252 @@
+"""
+Git Helper Plugin for Chat Auto Coder.
+Provides convenient Git commands and information display.
+"""
+
+import os
+import subprocess
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from autocoder.plugins import Plugin, PluginManager
+
+
+class GitHelperPlugin(Plugin):
+    """Git helper plugin for the Chat Auto Coder."""
+
+    name = "git_helper"
+    description = "Git helper plugin providing Git commands and status"
+    version = "0.1.0"
+
+    def __init__(self, manager: PluginManager, config: Optional[Dict[str, Any]] = None, config_path: Optional[str] = None):
+        """Initialize the Git helper plugin."""
+        super().__init__(manager, config, config_path)
+        self.git_available = self._check_git_available()
+        self.default_branch = self.config.get("default_branch", "main")
+
+    def _check_git_available(self) -> bool:
+        """Check if Git is available."""
+        try:
+            subprocess.run(
+                ["git", "--version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+            return True
+        except Exception:
+            return False
+
+    def initialize(self) -> bool:
+        """Initialize the plugin.
+
+        Returns:
+            True if initialization was successful
+        """
+        if not self.git_available:
+            print(f"[{self.name}] 警告: Git不可用，某些功能受限")
+            return True
+
+        print(f"[{self.name}] Git助手插件已初始化")
+        return True
+
+    def get_commands(self) -> Dict[str, Tuple[Callable, str]]:
+        """Get commands provided by this plugin.
+
+        Returns:
+            A dictionary of command name to handler and description
+        """
+        return {
+            "git/status": (self.git_status, "显示Git仓库状态"),
+            "git/commit": (self.git_commit, "提交更改"),
+            "git/branch": (self.git_branch, "显示或创建分支"),
+            "git/checkout": (self.git_checkout, "切换分支"),
+            "git/diff": (self.git_diff, "显示更改差异"),
+            "git/log": (self.git_log, "显示提交历史"),
+            "git/pull": (self.git_pull, "拉取远程更改"),
+            "git/push": (self.git_push, "推送本地更改到远程"),
+            "git/reset": (self.handle_reset, "重置当前分支到指定状态 (hard/soft/mixed)"),
+        }
+
+    def get_completions(self) -> Dict[str, List[str]]:
+        """Get completions provided by this plugin.
+
+        Returns:
+            A dictionary mapping command prefixes to completion options
+        """
+        completions = {
+            "/git/status": [],
+            "/git/commit": [],
+            "/git/branch": [],
+            "/git/checkout": [],
+            "/git/diff": [],
+            "/git/log": [],
+            "/git/pull": [],
+            "/git/push": [],
+            "/git/reset": ["hard", "soft", "mixed"],
+        }
+
+        # 添加分支补全
+        if self.git_available:
+            try:
+                branches = self._get_git_branches()
+                completions["/git/checkout"] = branches
+                completions["/git/branch"] = branches + [
+                    "--delete",
+                    "--all",
+                    "--remote",
+                    "new",
+                ]
+            except Exception:
+                pass
+
+        return completions
+
+    def _run_git_command(self, args: List[str]) -> Tuple[int, str, str]:
+        """Run a Git command.
+
+        Args:
+            args: The command arguments
+
+        Returns:
+            A tuple of (return_code, stdout, stderr)
+        """
+        if not self.git_available:
+            return 1, "", "Git不可用"
+
+        try:
+            process = subprocess.run(
+                ["git"] + args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            return process.returncode, process.stdout, process.stderr
+        except Exception as e:
+            return 1, "", str(e)
+
+    def _get_git_branches(self) -> List[str]:
+        """Get Git branches.
+
+        Returns:
+            A list of branch names
+        """
+        code, stdout, _ = self._run_git_command(
+            ["branch", "--list", "--format=%(refname:short)"]
+        )
+        if code == 0:
+            return [b.strip() for b in stdout.splitlines() if b.strip()]
+        return []
+
+    def git_status(self, args: str) -> None:
+        """Handle the git/status command."""
+        code, stdout, stderr = self._run_git_command(["status"])
+        if code == 0:
+            print(f"\n{stdout}")
+        else:
+            print(f"Error: {stderr}")
+
+    def git_commit(self, args: str) -> None:
+        """Handle the git/commit command."""
+        if not args:
+            print("请提供提交信息，例如: /git/commit 'Fix bug in login'")
+            return
+
+        # 首先执行添加所有更改 (git add .)
+        self._run_git_command(["add", "."])
+
+        # 执行提交
+        code, stdout, stderr = self._run_git_command(["commit", "-m", args])
+        if code == 0:
+            print(f"\n{stdout}")
+        else:
+            print(f"Error: {stderr}")
+
+    def git_branch(self, args: str) -> None:
+        """Handle the git/branch command."""
+        args_list = args.split() if args else []
+        code, stdout, stderr = self._run_git_command(["branch"] + args_list)
+        if code == 0:
+            print(f"\n{stdout}")
+        else:
+            print(f"Error: {stderr}")
+
+    def git_checkout(self, args: str) -> None:
+        """Handle the git/checkout command."""
+        if not args:
+            print("请提供分支名称，例如: /git/checkout main")
+            return
+
+        args_list = args.split()
+        code, stdout, stderr = self._run_git_command(["checkout"] + args_list)
+        if code == 0:
+            print(f"\n{stdout}")
+        else:
+            print(f"Error: {stderr}")
+
+    def git_diff(self, args: str) -> None:
+        """Handle the git/diff command."""
+        args_list = args.split() if args else []
+        code, stdout, stderr = self._run_git_command(["diff"] + args_list)
+        if code == 0:
+            if stdout:
+                print(f"\n{stdout}")
+            else:
+                print("没有差异")
+        else:
+            print(f"Error: {stderr}")
+
+    def git_log(self, args: str) -> None:
+        """Handle the git/log command."""
+        args_list = args.split() if args else ["--oneline", "-n", "10"]
+        code, stdout, stderr = self._run_git_command(["log"] + args_list)
+        if code == 0:
+            print(f"\n{stdout}")
+        else:
+            print(f"Error: {stderr}")
+
+    def git_pull(self, args: str) -> None:
+        """Handle the git/pull command."""
+        args_list = args.split() if args else []
+        code, stdout, stderr = self._run_git_command(["pull"] + args_list)
+        if code == 0:
+            print(f"\n{stdout}")
+        else:
+            print(f"Error: {stderr}")
+
+    def git_push(self, args: str) -> None:
+        """Handle the git/push command."""
+        args_list = args.split() if args else []
+        code, stdout, stderr = self._run_git_command(["push"] + args_list)
+        if code == 0:
+            print(f"\n{stdout}")
+        else:
+            print(f"Error: {stderr}")
+
+    def handle_reset(self, args: str) -> None:
+        """Handle the git/reset command.
+        
+        Args:
+            args: The reset mode (hard/soft/mixed) and optional commit hash
+        """
+        if not args:
+            print("请提供重置模式 (hard/soft/mixed) 和可选的提交哈希")
+            return
+            
+        args_list = args.split()
+        mode = args_list[0]
+        commit = args_list[1] if len(args_list) > 1 else "HEAD"
+        
+        if mode not in ["hard", "soft", "mixed"]:
+            print(f"错误: 无效的重置模式 '{mode}'，必须是 hard/soft/mixed 之一")
+            return
+            
+        code, stdout, stderr = self._run_git_command(["reset", f"--{mode}", commit])
+        if code == 0:
+            print(f"\n{stdout}")
+            print(f"成功将仓库重置为 {mode} 模式到 {commit}")
+        else:
+            print(f"Error: {stderr}")
+
+    def shutdown(self) -> None:
+        """Shutdown the plugin."""
+        print(f"[{self.name}] Git助手插件已关闭")

--- a/src/autocoder/plugins/sample_plugin.py
+++ b/src/autocoder/plugins/sample_plugin.py
@@ -1,0 +1,160 @@
+"""
+Sample plugin demonstrating the plugin system functionality.
+"""
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.formatted_text import FormattedText
+
+from autocoder.plugins import Plugin, PluginManager
+
+
+class SamplePlugin(Plugin):
+    """A sample plugin demonstrating the plugin system functionality."""
+
+    name = "sample_plugin"
+    description = "A sample plugin demonstrating the plugin system features"
+    version = "0.1.0"
+
+    def __init__(self, manager: PluginManager, config: Optional[Dict[str, Any]] = None, config_path: Optional[str] = None):
+        """Initialize the sample plugin."""
+        super().__init__(manager, config, config_path)
+        self.counter = 0
+
+    def initialize(self) -> bool:
+        """Initialize the plugin.
+
+        Returns:
+            True if initialization was successful
+        """
+        print(f"[{self.name}] Initializing sample plugin")
+
+        # Register interest in intercepting functions
+        self.manager.register_function_interception(self.name, "ask")
+        self.manager.register_function_interception(self.name, "coding")
+
+        return True
+
+    def get_commands(self) -> Dict[str, Tuple[Callable, str]]:
+        """Get commands provided by this plugin.
+
+        Returns:
+            A dictionary of command name to handler and description
+        """
+        return {
+            "sample": (self.sample_command, "Sample plugin command"),
+            "counter": (self.counter_command, "Show the plugin counter"),
+        }
+
+    def get_keybindings(self) -> List[Tuple[str, Callable, str]]:
+        """Get keybindings provided by this plugin.
+
+        Returns:
+            A list of (key_combination, handler, description) tuples
+        """
+
+        def increment_counter(event):
+            self.counter += 1
+            print(f"[{self.name}] Counter incremented to {self.counter}")
+
+        return [
+            ("c-p", increment_counter, "Increment plugin counter"),
+        ]
+
+    def get_completions(self) -> Dict[str, List[str]]:
+        """Get completions provided by this plugin.
+
+        Returns:
+            A dictionary mapping command prefixes to completion options
+        """
+        return {
+            "/sample": ["option1", "option2", "option3"],
+            "/counter": ["show", "reset", "increment"],
+        }
+
+    def sample_command(self, args: str) -> None:
+        """Handle the sample command.
+
+        Args:
+            args: Command arguments
+        """
+        print(f"[{self.name}] Sample command executed with args: {args}")
+        self.counter += 1
+        print(f"[{self.name}] Counter incremented to {self.counter}")
+
+    def counter_command(self, args: str) -> None:
+        """Handle the counter command.
+
+        Args:
+            args: Command arguments
+        """
+        if args == "reset":
+            self.counter = 0
+            print(f"[{self.name}] Counter reset to {self.counter}")
+        elif args == "increment":
+            self.counter += 1
+            print(f"[{self.name}] Counter incremented to {self.counter}")
+        else:
+            print(f"[{self.name}] Current counter value: {self.counter}")
+
+    def intercept_command(
+        self, command: str, args: str
+    ) -> Tuple[bool, Optional[str], Optional[str]]:
+        """Intercept commands.
+
+        Args:
+            command: The command name (without the /)
+            args: The command arguments
+
+        Returns:
+            A tuple of (should_continue, modified_command, modified_args)
+        """
+        # Log all commands
+        print(f"[{self.name}] Command intercepted: /{command} {args}")
+
+        # Example: modify the 'ask' command to add a prefix
+        if command == "ask" and args:
+            return True, command, f"[From Sample Plugin] {args}"
+
+        return True, command, args
+
+    def intercept_function(
+        self, func_name: str, args: List[Any], kwargs: Dict[str, Any]
+    ) -> Tuple[bool, List[Any], Dict[str, Any]]:
+        """Intercept function calls.
+
+        Args:
+            func_name: The function name
+            args: The positional arguments
+            kwargs: The keyword arguments
+
+        Returns:
+            A tuple of (should_continue, modified_args, modified_kwargs)
+        """
+        print(f"[{self.name}] Function intercepted: {func_name}")
+
+        # Example: modify the 'coding' function to add a prefix to the query
+        if func_name == "coding" and args:
+            args = list(args)  # Convert tuple to list for modification
+            if isinstance(args[0], str):
+                args[0] = f"[Enhanced by Sample Plugin] {args[0]}"
+
+        return True, args, kwargs
+
+    def post_function(self, func_name: str, result: Any) -> Any:
+        """Process function results.
+
+        Args:
+            func_name: The function name
+            result: The function result
+
+        Returns:
+            The possibly modified result
+        """
+        print(f"[{self.name}] Function completed: {func_name}")
+        return result
+
+    def shutdown(self) -> None:
+        """Shutdown the plugin."""
+        print(f"[{self.name}] Shutting down sample plugin (counter: {self.counter})")

--- a/src/autocoder/plugins/utils.py
+++ b/src/autocoder/plugins/utils.py
@@ -1,0 +1,9 @@
+import json
+
+def load_json_file(file_path: str) -> dict:
+    with open(file_path, 'r') as f:
+        return json.load(f)
+
+def save_json_file(file_path: str, data: dict):
+    with open(file_path, 'w') as f:
+        json.dump(data, f, ensure_ascii=False, indent=4)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+测试Chat Auto Coder的插件系统
+"""
+
+import os
+import sys
+import json
+import unittest
+import tempfile
+from unittest import TestCase
+from typing import Dict, Any, List, Tuple, Optional, Callable
+from unittest.mock import MagicMock, patch
+
+# 添加src目录到Python路径
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+from autocoder.plugins import PluginManager, Plugin
+from prompt_toolkit.document import Document
+from prompt_toolkit.completion import Completion
+
+# 导入需要测试的 EnhancedCompleter 类
+try:
+    from autocoder.chat_auto_coder import EnhancedCompleter as ActualEnhancedCompleter
+    # 使用别名避免类型兼容性问题
+    EnhancedCompleter = ActualEnhancedCompleter  # type: ignore
+except ImportError:
+    # 为防止导入错误，创建一个模拟版本的 EnhancedCompleter
+    class EnhancedCompleter:
+        def __init__(self, base_completer, plugin_manager):
+            self.base_completer = base_completer
+            self.plugin_manager = plugin_manager
+
+
+class PluginTester(Plugin):
+    """测试用插件类."""
+
+    name = "plugin_tester"
+    description = "测试用插件"
+    version = "0.1.0"
+
+    def __init__(self, manager, config=None, config_path=None):
+        super().__init__(manager, config, config_path)
+        self.test_counter = 0
+        self.initialization_called = False
+
+    def initialize(self):
+        self.initialization_called = True
+        return True
+
+    def get_commands(self):
+        return {
+            "test": (self.test_command, "测试命令"),
+        }
+
+    def test_command(self, args):
+        self.test_counter += 1
+        return f"测试命令已执行，参数: {args}, 计数: {self.test_counter}"
+
+    def shutdown(self):
+        self.test_counter = 0
+
+
+class SimplePlugin(Plugin):
+    """一个简单的测试插件"""
+
+    name = "simple_plugin"
+    description = "简单测试插件"
+    version = "0.1.0"
+
+    def __init__(self, manager, config=None, config_path=None):
+        super().__init__(manager, config, config_path)
+        self.initialized = False
+        self.command_executed = False
+        self.command_args = None
+
+    def initialize(self):
+        self.initialized = True
+        return True
+
+    def get_commands(self):
+        return {
+            "simple": (self.simple_command, "简单测试命令"),
+        }
+
+    def simple_command(self, args):
+        self.command_executed = True
+        self.command_args = (
+            args[0] if isinstance(args, list) else args
+        )  # 适应不同的参数格式
+        return f"简单命令执行成功，参数: {args}"
+
+    def shutdown(self):
+        self.initialized = False
+        self.command_executed = False
+        self.command_args = None
+
+
+class TestPluginSystem(TestCase):
+    """插件系统测试用例"""
+
+    def setUp(self):
+        """每个测试用例前的设置"""
+        # 创建插件管理器
+        self.manager = PluginManager()
+
+        # 添加测试目录作为插件目录
+        self.test_dir = os.path.dirname(os.path.abspath(__file__))
+        self.manager.add_plugin_directory(self.test_dir)
+
+        # 临时文件用于测试配置加载
+        self.temp_config_file = None
+
+    def tearDown(self):
+        """每个测试用例后的清理"""
+        # 关闭所有插件
+        if hasattr(self, "manager"):
+            self.manager.shutdown_all()
+
+        # 删除临时配置文件
+        if self.temp_config_file and os.path.exists(self.temp_config_file):
+            os.remove(self.temp_config_file)
+
+    def test_plugin_discovery(self):
+        """测试插件发现功能"""
+        discovered_plugins = self.manager.discover_plugins()
+        # 确保能发现某些插件类
+        self.assertTrue(len(discovered_plugins) > 0, "未能发现任何插件")
+
+        # 查看发现的插件类名
+        plugin_names = [p.__name__ for p in discovered_plugins]
+        self.assertIn("PluginTester", plugin_names, "未能发现测试插件")
+
+    def test_plugin_loading(self):
+        """测试插件加载功能"""
+        # 手动加载测试插件
+        plugin_loaded = self.manager.load_plugin(
+            PluginTester, {"test_setting": "test_value"}
+        )
+        self.assertTrue(plugin_loaded, "未能加载测试插件")
+
+        # 验证插件是否已加载
+        plugin_id = PluginTester.id_name()
+        plugin = self.manager.plugins.get(plugin_id)
+        self.assertIsNotNone(plugin, "无法通过名称获取已加载的插件")
+        self.assertEqual(plugin.name, "plugin_tester", "插件名称不匹配")
+        self.assertTrue(plugin.initialization_called, "插件的initialize方法未被调用")
+
+    def test_command_processing(self):
+        """测试命令处理功能"""
+        # 加载测试插件
+        self.manager.load_plugin(PluginTester, {})
+
+        # 测试命令处理
+        cmd_result = self.manager.process_command("/test with some args")
+        self.assertIsNotNone(cmd_result, "未能处理命令")
+
+        if cmd_result:
+            plugin_name, handler, args = cmd_result
+            self.assertEqual(plugin_name, PluginTester.id_name(), "处理的插件名称不正确")
+            # 根据实际实现调整预期的参数格式
+            self.assertEqual(args, ["with some args"], "命令参数解析不正确")
+
+            # 执行处理程序
+            if handler:
+                result = handler(*args)
+                self.assertIn("测试命令已执行", result, "命令处理结果不符合预期")
+                self.assertIn("计数: 1", result, "命令处理计数器不符合预期")
+
+    def test_function_interception(self):
+        """测试函数拦截功能"""
+        # 加载测试插件
+        plugin_id = PluginTester.id_name()
+        self.manager.load_plugin(PluginTester, {})
+
+        # 定义测试函数
+        def test_func(text):
+            return f"原始结果: {text}"
+
+        # 注册函数拦截
+        self.manager.register_function_interception(plugin_id, "test_func")
+
+        # 包装函数
+        wrapped_func = self.manager.wrap_function(test_func, "test_func")
+
+        # 执行包装后的函数
+        result = wrapped_func("测试参数")
+        self.assertEqual(result, "原始结果: 测试参数", "函数拦截修改了原始结果")
+
+    def test_config_loading(self):
+        """测试从配置加载插件"""
+        # 创建测试配置文件
+        plugin_id = PluginTester.id_name()
+        config = {
+            "plugin_dirs": [self.test_dir],
+            "plugins": [plugin_id]
+        }
+
+        # 使用临时文件，以文本模式打开
+        with tempfile.NamedTemporaryFile(
+            delete=False, suffix=".json", mode="w"
+        ) as temp:
+            self.temp_config_file = temp.name
+            json.dump(config, temp, indent=2)
+
+        # 尝试从配置加载插件
+        try:
+            # 先添加测试插件类到插件管理器的缓存中，确保它能被发现
+            self._discover_plugins_cache = self.manager._discover_plugins_cache
+            if self._discover_plugins_cache is None:
+                self._discover_plugins_cache = [PluginTester]
+                self.manager._discover_plugins_cache = self._discover_plugins_cache
+            elif PluginTester not in self._discover_plugins_cache:
+                self._discover_plugins_cache.append(PluginTester)
+            
+            # 现在加载配置
+            self.manager.load_plugins_from_config(config)
+
+            # 验证插件是否已加载
+            plugin = self.manager.plugins.get(plugin_id)
+            self.assertIsNotNone(plugin, "未能从配置加载插件")
+
+        except Exception as e:
+            self.fail(f"从配置加载插件失败: {e}")
+
+    def test_simple_plugin_basic(self):
+        """测试简单插件的基本功能"""
+        # 加载插件
+        plugin_config = {"test_mode": True}
+        plugin_id = SimplePlugin.id_name()
+        plugin_loaded = self.manager.load_plugin(SimplePlugin, plugin_config)
+
+        # 验证插件已加载
+        self.assertTrue(plugin_loaded, "插件加载失败")
+
+        # 获取插件实例
+        plugin = self.manager.plugins.get(plugin_id)
+        self.assertIsNotNone(plugin, "无法获取插件实例")
+
+        # 检查初始化状态
+        if plugin:
+            self.assertTrue(plugin.initialized, "插件未正确初始化")
+            if hasattr(plugin, "config"):
+                self.assertEqual(
+                    plugin.config.get("test_mode"), True, "插件配置未正确传递"
+                )
+
+        # 测试命令处理
+        cmd_result = self.manager.process_command("/simple arg1 arg2")
+        self.assertIsNotNone(cmd_result, "命令处理失败")
+
+        # 验证命令处理结果
+        if cmd_result and plugin:
+            plugin_name, handler, args = cmd_result
+            self.assertEqual(plugin_name, plugin_id, "插件名称不匹配")
+            # 根据实际实现调整预期的参数格式
+            self.assertEqual(args, ["arg1 arg2"], "命令参数解析错误")
+
+            # 执行命令处理程序
+            if handler:
+                result = handler(*args)
+                self.assertIn("简单命令执行成功", result, "命令执行结果不符合预期")
+
+                # 验证插件状态
+                self.assertTrue(plugin.command_executed, "命令未被标记为已执行")
+                self.assertEqual(plugin.command_args, "arg1 arg2", "命令参数未正确保存")
+
+    def test_simple_plugins_collection(self):
+        """测试简单插件的集合功能"""
+        # 加载多个插件实例
+        self.manager.load_plugin(SimplePlugin, {"id": "plugin1"})
+        self.manager.load_plugin(SimplePlugin, {"id": "plugin2"})
+
+        # 获取所有命令
+        all_commands = self.manager.get_all_commands()
+        # 调整检查方式，根据实际格式检查键是否包含simple
+        command_keys = list(all_commands.keys())
+        self.assertTrue(
+            any("simple" in key for key in command_keys), "无法获取插件命令"
+        )
+
+        # 使用manager的shutdown_all方法关闭所有插件
+        self.manager.shutdown_all()
+
+        # 手动清理插件字典，确保没有引用
+        if hasattr(self.manager, "plugins"):
+            # 清空插件字典
+            keys = list(self.manager.plugins.keys())
+            for key in keys:
+                self.manager.plugins.pop(key, None)
+
+        # 验证所有插件都已关闭
+        plugin = self.manager.get_plugin("simple_plugin")
+        self.assertIsNone(plugin, "插件关闭后仍能获取到插件实例")
+
+    def test_dynamic_completions(self):
+        """测试动态补全功能"""
+
+        # 创建一个支持动态补全的测试插件类
+        class DynamicCompletionPlugin(Plugin):
+            name = "dynamic_completion_test"
+            description = "测试动态补全功能"
+            version = "0.1.0"
+            
+            def __init__(self, manager, config=None, config_path=None):
+                super().__init__(manager, config, config_path)
+                self.registered_commands = []
+
+            def get_dynamic_completions(self, command, current_input):
+                if command == "/test_cmd":
+                    return [("option1", "Option 1"), ("option2", "Option 2")]
+                return []
+
+        # 加载插件
+        self.manager.load_plugin(DynamicCompletionPlugin)
+
+        # 测试动态补全功能
+        completions = self.manager.get_dynamic_completions("/test_cmd", "/test_cmd ")
+        self.assertEqual(len(completions), 2, "未能获取正确数量的动态补全选项")
+        self.assertEqual(completions[0][0], "option1", "补全选项不正确")
+        self.assertEqual(completions[1][1], "Option 2", "显示文本不正确")
+
+    def test_plugins_load_completions(self):
+        """测试内置的/plugins /load命令补全功能"""
+        # 确保插件管理器可以发现插件
+        discovered_plugins = self.manager.discover_plugins()
+        self.assertTrue(len(discovered_plugins) > 0, "没有可发现的插件")
+
+        # 测试/plugins /load命令的动态补全
+        completions = self.manager.get_dynamic_completions(
+            "/plugins /load", "/plugins /load"
+        )
+        self.assertTrue(len(completions) > 0, "未能获取/plugins /load命令的补全选项")
+
+        # 验证补全项格式
+        for completion_text, display_text in completions:
+            # 根据新实现，display_text可能包含补充信息
+            self.assertTrue(completion_text in display_text, "补全文本应包含在显示文本中")
+
+        # 测试插件名称前缀过滤
+        plugin_name = completions[0][0]  # 获取第一个插件名称
+        if len(plugin_name) > 1:
+            prefix = plugin_name[0]
+            filtered_completions = self.manager.get_dynamic_completions(
+                "/plugins /load", f"/plugins /load {prefix}"
+            )
+            if filtered_completions:  # 如果有匹配项
+                self.assertTrue(
+                    all(name[0].startswith(prefix) for name, _ in filtered_completions),
+                    "前缀过滤功能不正确",
+                )
+
+    def test_enhanced_completer(self):
+        """测试EnhancedCompleter类的动态补全功能"""
+        try:
+            # 确保EnhancedCompleter类可用
+            from autocoder.chat_auto_coder import EnhancedCompleter as ActualEnhancedCompleter
+        except ImportError:
+            self.skipTest("EnhancedCompleter类不可用")
+            return
+
+        # 创建一个支持动态补全的测试插件类
+        class DynamicCompletionPlugin(Plugin):
+            name = "dynamic_completion_test"
+            description = "测试动态补全功能"
+            version = "0.1.0"
+            
+            def __init__(self, manager, config=None, config_path=None):
+                super().__init__(manager, config, config_path)
+                self.registered_commands = []
+
+            def get_dynamic_completions(self, command, current_input):
+                self.registered_commands.append(command)
+                if command == "/test_cmd":
+                    return [("option1", "Option 1"), ("option2", "Option 2")]
+                return []
+
+            def get_completions(self):
+                return {"/test_cmd": ["subcommand1", "subcommand2"]}
+
+        # 加载插件
+        self.manager.load_plugin(DynamicCompletionPlugin)
+
+        # 创建一个模拟的基础补全器
+        mock_base_completer = MagicMock()
+        mock_base_completer.get_completions.return_value = []
+
+        # 创建EnhancedCompleter实例
+        completer = ActualEnhancedCompleter(mock_base_completer, self.manager)
+
+        # 测试空格后的动态补全
+        document = Document("/test_cmd ")
+        mock_complete_event = MagicMock()
+
+        # 收集补全结果
+        completions = list(completer.get_completions(document, mock_complete_event))
+
+        # 验证结果
+        self.assertTrue(len(completions) > 0, "未能获取动态补全选项")
+
+        # 测试子命令补全
+        document = Document("/test_cmd sub")
+        completions = list(completer.get_completions(document, mock_complete_event))
+
+        # 验证子命令补全结果
+        has_subcommand_completions = any(
+            c.text == "subcommand1" or c.text == "subcommand2" for c in completions
+        )
+        self.assertTrue(
+            has_subcommand_completions or len(completions) > 0, "未能正确处理子命令补全"
+        )
+
+    def test_register_dynamic_completion_provider(self):
+        """测试注册动态补全提供者功能"""
+
+        # 创建一个支持动态补全的测试插件类
+        class DynamicCompletionPlugin(Plugin):
+            name = "dynamic_provider_test"
+            description = "测试动态补全提供者注册功能"
+            version = "0.1.0"
+            
+            def __init__(self, manager, config=None, config_path=None):
+                super().__init__(manager, config, config_path)
+                self.registered_commands = []
+
+            def initialize(self):
+                # 注册为动态补全提供者
+                self.manager.register_dynamic_completion_provider(
+                    self.name, ["/custom_cmd", "/another_cmd"]
+                )
+                return True
+
+            def get_dynamic_completions(self, command, current_input):
+                self.registered_commands.append(command)
+                if command == "/custom_cmd":
+                    return [("custom_option", "Custom Option")]
+                return []
+
+        # 加载插件
+        plugin_loaded = self.manager.load_plugin(DynamicCompletionPlugin)
+        self.assertTrue(plugin_loaded, "未能加载动态补全测试插件")
+
+        # 获取插件实例
+        plugin_id = DynamicCompletionPlugin.id_name()
+        plugin = self.manager.plugins.get(plugin_id)
+        self.assertIsNotNone(plugin, "无法获取插件实例")
+
+        # 测试动态补全 - register_dynamic_completion_provider可能是个空方法
+        # 但这个测试为未来实现提供了基础
+        completions = self.manager.get_dynamic_completions("/custom_cmd", "/custom_cmd")
+
+        # 验证插件的get_dynamic_completions被调用
+        if plugin and hasattr(plugin, "registered_commands"):
+            self.assertIn(
+                "/custom_cmd", plugin.registered_commands, "动态补全提供者未被正确注册"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Chat Auto Coder 插件系统

本目录包含 Chat Auto Coder 的插件系统，允许在运行时扩展应用程序的功能。

## 插件系统特性

- 向 Chat Auto Coder 添加新命令
- 拦截和修改现有命令
- 拦截和修改函数调用
- 添加自定义键绑定
- 提供命令补全功能
- 非侵入式架构（不需要修改现有代码）

## 使用插件

在运行时使用 `/plugins` 命令：
   ```
   /plugins list              # 列出可用插件
   /plugins load PluginClass  # 加载特定插件
   /plugins unload PluginName # 卸载插件
   /plugins                   # 显示已加载插件
   ```

## 插件目录

Chat Auto Coder 支持两种类型的插件目录：

1. **项目特定插件目录**：仅在当前项目中可用。
2. **全局插件目录**：对当前用户的所有项目都可用。

### 管理插件目录

您可以使用 `/plugins/dirs` 命令管理插件目录：

```
/plugins/dirs                # 列出所有插件目录（全局和项目特定）
/plugins/dirs /add <path>    # 添加项目特定插件目录
/plugins/dirs /remove <path> # 删除项目特定插件目录
/plugins/dirs /clear         # 清除所有项目特定插件目录
```

全局插件目录存储在 `~/.auto-coder/plugins/global_plugin_dirs` 文件中，并在 Chat Auto Coder 启动时自动加载。它们在所有项目中保持可用。

要添加全局插件目录，您需要直接编辑全局插件目录文件，或使用代码中的API。

## 创建插件

要创建插件，需要继承 `autocoder.plugins` 中的 `Plugin` 类：

```python
from autocoder.plugins import Plugin

class MyPlugin(Plugin):
    name = "my_plugin"
    description = "我的自定义插件"
    version = "0.1.0"
    
    def __init__(self, manager, config=None, config_path=None):
        super().__init__(manager, config, config_path)
        # 初始化您的插件
    
    def initialize(self):
        # 此方法用于插件自身的初始化
        # 您可以在这里设置资源、注册事件处理程序或执行任何启动任务
        # 下面的register_function_interception只是一个示例，说明您可能在这里做什么
        self.manager.register_function_interception(self.name, "ask")
        return True
    
    def get_commands(self):
        return {
            "my_command": (self.my_command_handler, "我的自定义命令"),
        }
    
    def my_command_handler(self, args):
        print(f"我的命令已执行，参数: {args}")
    
    def get_keybindings(self):
        return [
            ("c-m", self.my_keybinding_handler, "我的自定义按键绑定"),
        ]
    
    def my_keybinding_handler(self, event):
        print("我的按键被按下！")
    
    def intercept_command(self, command, args):
        # 返回 True, command, args 允许正常处理
        # 返回 False, new_command, new_args 接管处理
        return True, command, args
    
    def intercept_function(self, func_name, args, kwargs):
        # 根据需要修改 args 或 kwargs
        return True, args, kwargs
    
    def post_function(self, func_name, result):
        # 根据需要修改结果
        return result
    
    def export_config(self, config_path=None):
        # 导出插件配置用于持久化存储
        # 如果不需要配置，返回 None
        return self.config
    
    def shutdown(self):
        # 清理资源
        pass
```

## 插件配置

每个插件的配置单独存储在项目的 `.auto-coder/plugins/{plugin_id}/config.json` 目录中。插件管理器负责加载和保存这些配置。

全局插件目录存储在 `~/.auto-coder/plugins/global_plugin_dirs` 文件中，并对所有项目自动加载。

## 内置插件

Chat Auto Coder 包含以下插件：

- `SamplePlugin`：演示基本功能的示例插件
- `DynamicCompletionExamplePlugin`：演示动态命令补全功能的插件
- `GitHelperPlugin`：Git 命令插件


## 插件标识

每个插件通过 `id_name()` 类方法获取完整的模块和类名作为唯一标识符：

```python
@classmethod
def id_name(cls) -> str:
    """返回插件的唯一标识符，包括模块路径"""
    return f"{cls.__module__}.{cls.__name__}"
```

此标识符用于插件注册、加载和配置管理。

## 插件 API 参考

### Plugin 类

所有插件的基类：

- `name`：插件名称（字符串）
- `description`：插件描述（字符串）
- `version`：插件版本（字符串）
- `dynamic_cmds`：需要动态补全的命令列表（字符串列表）。此列表指定哪些命令应该根据当前上下文使用动态补全。例如，插件可以将其设置为 `["/my_command"]` 来表示 `/my_command` 应该有动态补全。
- `initialize()`：插件加载时调用。用于插件自身初始化，例如设置资源、连接服务或任何其他启动任务。初始化成功返回`True`，否则返回`False`。
- `get_commands()`：返回插件提供的命令字典
- `get_keybindings()`：返回插件提供的按键绑定列表
- `get_completions()`：返回命令补全字典
- `get_dynamic_completions(command, current_input)`：根据输入上下文返回动态补全选项
- `intercept_command(command, args)`：拦截并可能修改命令
- `intercept_function(func_name, args, kwargs)`：拦截并可能修改函数调用
- `post_function(func_name, result)`：处理函数结果
- `export_config(config_path)`：导出插件配置
- `shutdown()`：插件卸载或应用程序退出时调用

### PluginManager 类

管理 Chat Auto Coder 的插件：

- `add_plugin_directory(directory)`：添加用于搜索插件的目录（项目特定）
- `add_global_plugin_directory(directory)`：添加用于搜索插件的全局目录（对所有项目可用）
- `remove_plugin_directory(directory)`：删除项目特定插件目录
- `clear_plugin_directories()`：清除所有项目特定插件目录
- `load_global_plugin_dirs()`：从 ~/.auto-coder/plugins/global_plugin_dirs 加载全局插件目录
- `save_global_plugin_dirs()`：保存全局插件目录到 ~/.auto-coder/plugins/global_plugin_dirs
- `discover_plugins()`：在插件目录中发现可用插件
- `load_plugin(plugin_class, config)`：加载并初始化插件
- `load_plugins_from_config(config)`：基于配置加载插件
- `get_plugin(name)`：通过名称获取插件
- `process_command(full_command)`：处理命令，允许插件拦截
- `wrap_function(original_func, func_name)`：包装函数以允许插件拦截
- `register_function_interception(plugin_name, func_name)`：注册插件对拦截函数的兴趣
- `get_all_commands()`：获取所有插件的所有命令
- `get_plugin_completions()`：获取所有插件的命令补全
- `get_dynamic_completions(command, current_input)`：根据当前输入获取动态补全选项
- `load_runtime_cfg()`：加载插件的运行时配置
- `save_runtime_cfg()`：保存插件的运行时配置
- `shutdown_all()`：关闭所有插件

### 模块级别函数

`autocoder.plugins` 模块还提供以下函数：

- `register_global_plugin_dir(directory)`：在插件安装过程中将目录注册为全局插件目录。这是为插件安装脚本提供的便捷函数。

## 插件安装与注册

在创建插件安装脚本时，您可以使用 `register_global_plugin_dir` 模块级别函数自动将插件目录注册为全局插件目录。这使得插件对用户机器上的所有项目都可用。

### 示例：插件安装脚本

```python
#!/usr/bin/env python3
import os
import sys
from pathlib import Path

def install_plugin():
    """安装插件并全局注册。"""
    # 获取当前目录（插件代码所在位置）
    plugin_dir = os.path.dirname(os.path.abspath(__file__))
    
    try:
        # 导入插件管理器模块
        sys.path.insert(0, str(Path(plugin_dir).parent))
        from autocoder.plugins import register_global_plugin_dir
        
        # 使用模块函数将插件目录全局注册
        register_global_plugin_dir(plugin_dir)
        print(f"✅ 成功注册插件目录：{plugin_dir}")
        print(f"该插件现在可用于所有 Chat Auto Coder 项目。")
            
        return True
    except Exception as e:
        print(f"❌ 插件安装过程中出错：{str(e)}")
        return False

if __name__ == "__main__":
    if install_plugin():
        print("安装成功完成！")
    else:
        print("安装失败。请查看上面的错误信息。") 