### PR TITLE
Add local image hosting support for RAG chat application

### DIFF
--- a/src/autocoder/auto_coder_rag.py
+++ b/src/autocoder/auto_coder_rag.py
@@ -274,6 +274,7 @@ def main(input_args: Optional[List[str]] = None):
     serve_parser.add_argument("--ssl_certfile", default="", help="")
     serve_parser.add_argument("--response_role", default="assistant", help="")
     serve_parser.add_argument("--doc_dir", default="", help="")
+    serve_parser.add_argument("--enable_local_image_host", action="store_true", help=" enable local image host for local Chat app")
     serve_parser.add_argument("--tokenizer_path", default=tokenizer_path, help="")
     serve_parser.add_argument(
         "--collections", default="", help="Collection name for indexing"
@@ -516,6 +517,12 @@ def main(input_args: Optional[List[str]] = None):
                 if hasattr(args, arg)
             }
         )
+        # 设置本地图床的地址
+        if args.enable_local_image_host:
+            host = server_args.host or "127.0.0.1"
+            port = str(server_args.port)
+            auto_coder_args.local_image_host = f"{host}:{port}"
+
 
         # Generate unique name for RAG build if doc_dir exists
         if server_args.doc_dir:

--- a/src/autocoder/common/__init__.py
+++ b/src/autocoder/common/__init__.py
@@ -296,6 +296,9 @@ class AutoCoderArgs(pydantic.BaseModel):
     rag_params_max_tokens: Optional[int] = 4096 
     rag_doc_filter_relevance: Optional[int] = 5
     rag_context_window_limit: Optional[int] = 120000 
+
+    # rag 本地图床地址
+    local_image_host: Optional[str] = ""
     
     # 回答用户问题时，使用哪种对话历史策略
     # single_round: 单轮对话

--- a/src/autocoder/rag/api_server.py
+++ b/src/autocoder/rag/api_server.py
@@ -5,6 +5,9 @@ from fastapi import Request
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse, Response
+from fastapi import HTTPException
+import mimetypes
+from urllib.parse import unquote
 
 from byzerllm.log import init_logger
 from byzerllm.utils import random_uuid
@@ -117,6 +120,49 @@ async def create_chat_completion(
         )
     else:
         return JSONResponse(content=generator.model_dump())
+
+
+@router_app.get("/{full_path:path}")
+async def serve_image(full_path: str, request: Request):
+        
+    allowed_file_type = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp']
+    
+    if any(full_path.endswith(ext) for ext in allowed_file_type):
+        try:
+            # 获取文件的完整路径，并进行URL解码
+            file_path = unquote(full_path)
+            # 使用 os.path.normpath 来标准化路径，自动处理不同操作系统的路径分隔符
+            file_path = os.path.normpath(file_path)
+            if not os.path.isabs(file_path):
+                file_path = os.path.join("/", file_path)
+            
+            # 检查文件是否存在
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"File not found: {file_path}")
+                
+            # 读取文件内容
+            with open(file_path, "rb") as f:
+                content = f.read()
+            
+            # 获取文件的 MIME 类型
+            content_type = mimetypes.guess_type(file_path)[0]
+            if not content_type:
+                content_type = "application/octet-stream"
+                
+            # 返回文件内容
+            return Response(content=content, media_type=content_type)
+        except FileNotFoundError as e:
+            logger.error(f"Image not found: {str(e)}")
+            raise HTTPException(status_code=404, detail=f"Image not found: {str(e)}")
+        except PermissionError as e:
+            logger.error(f"Permission denied: {str(e)}")
+            raise HTTPException(status_code=403, detail=f"Permission denied: {str(e)}")
+        except Exception as e:
+            logger.error(f"Error serving image: {str(e)}")
+            raise HTTPException(status_code=500, detail=f"Error serving image: {str(e)}")
+    
+    # 如果路径中没有图片, 返回 404
+    raise HTTPException(status_code=404, detail="Only images are supported")
 
 
 @router_app.post("/v1/embeddings")

--- a/src/autocoder/rag/long_context_rag.py
+++ b/src/autocoder/rag/long_context_rag.py
@@ -833,7 +833,7 @@ class LongContextRAG:
                     self.args.rag_qa_conversation_strategy)
                 new_conversations = qa_strategy.create_conversation(
                     documents=[doc.source_code for doc in relevant_docs],
-                    conversations=conversations
+                    conversations=conversations, local_image_host=self.args.local_image_host
                 )
 
                 chunks = target_llm.stream_chat_oai(

--- a/src/autocoder/rag/qa_conversation_strategy.py
+++ b/src/autocoder/rag/qa_conversation_strategy.py
@@ -8,7 +8,7 @@ class QAConversationStrategy(ABC):
     Different strategies organize documents and conversations differently.
     """
     @abstractmethod
-    def create_conversation(self, documents: List[Any], conversations: List[Dict[str,str]]) -> List[Dict]:
+    def create_conversation(self, documents: List[Any], conversations: List[Dict[str,str]], local_image_host: str) -> List[Dict]:
         """
         Create a conversation structure based on documents and history
         
@@ -26,10 +26,10 @@ class MultiRoundStrategy(QAConversationStrategy):
     Multi-round strategy: First let the model read documents, then do Q&A.
     Creates multiple conversation turns.
     """
-    def create_conversation(self, documents: List[Any], conversations: List[Dict[str,str]]) -> List[Dict]:
+    def create_conversation(self, documents: List[Any], conversations: List[Dict[str,str]], local_image_host: str) -> List[Dict]:
         messages = []    
         messages.extend([
-            {"role": "user", "content": self._read_docs_prompt.prompt(documents)},
+            {"role": "user", "content": self._read_docs_prompt.prompt(documents, local_image_host)},
             {"role": "assistant", "content": "好的"}
         ]) 
         messages.extend(conversations)
@@ -37,7 +37,7 @@ class MultiRoundStrategy(QAConversationStrategy):
     
     @byzerllm.prompt()
     def _read_docs_prompt(
-        self, relevant_docs: List[str]
+        self, relevant_docs: List[str], local_image_host: str
     ) -> Generator[str, None, None]:
         """        
         请阅读以下：
@@ -53,29 +53,35 @@ class MultiRoundStrategy(QAConversationStrategy):
         - 如果文档提供的信息无法回答问题,请明确回复:"抱歉,文档中没有足够的信息来回答这个问题。" 
         - 不要添加、推测或扩展文档未提及的信息
 
-        2. 格式如 ![image](./path.png) 的 Markdown 图片处理
+        2. 格式如 ![image](/path/to/images/path.png) 的 Markdown 图片处理
         - 根据Markdown 图片前后文本内容推测改图片与问题的相关性，有相关性则在回答中输出该Markdown图片路径
         - 根据相关图片在文档中的位置，自然融入答复内容,保持上下文连贯
         - 完整保留原始图片路径,不省略任何部分
 
         3. 回答格式要求
         - 使用markdown格式提升可读性        
+        {% if local_image_host %}
+        4. 图片路径处理
+        - 图片地址需返回绝对路径, 
+        - 为请求图片资源 需增加 http://{{ local_image_host }}/ 作为前缀
+        例如：/path/to/images/image.png， 返回 http://{{ local_image_host }}/path/to/images/image.png
+        {% endif %}
         """
 
 class SingleRoundStrategy(QAConversationStrategy):
     """
     Single-round strategy: Put documents and conversation history in a single round.
     """
-    def create_conversation(self, documents: List[Any], conversations: List[Dict[str,str]]) -> List[Dict]:
+    def create_conversation(self, documents: List[Any], conversations: List[Dict[str,str]], local_image_host: str) -> List[Dict]:
         messages = []                
         messages.extend([
-            {"role": "user", "content": self._single_round_answer_question.prompt(documents, conversations)}
+            {"role": "user", "content": self._single_round_answer_question.prompt(documents, conversations, local_image_host)}
         ])         
         return messages
     
     @byzerllm.prompt()
     def _single_round_answer_question(
-        self, relevant_docs: List[str], conversations: List[Dict[str, str]]
+        self, relevant_docs: List[str], conversations: List[Dict[str, str]], local_image_host: str
     ) -> Generator[str, None, None]:
         """        
         文档：
@@ -98,14 +104,19 @@ class SingleRoundStrategy(QAConversationStrategy):
         - 如果文档提供的信息无法回答问题,请明确回复:"抱歉,文档中没有足够的信息来回答这个问题。" 
         - 不要添加、推测或扩展文档未提及的信息
 
-        2. 格式如 ![image](./path.png) 的 Markdown 图片处理
+        2. 格式如 ![image](/path/to/images/path.png) 的 Markdown 图片处理
         - 根据Markdown 图片前后文本内容推测改图片与问题的相关性，有相关性则在回答中输出该Markdown图片路径
         - 根据相关图片在文档中的位置，自然融入答复内容,保持上下文连贯
         - 完整保留原始图片路径,不省略任何部分
 
         3. 回答格式要求
         - 使用markdown格式提升可读性
-        
+        {% if local_image_host %}
+        4. 图片路径处理
+        - 图片地址需返回绝对路径, 
+        - 为请求图片资源 需增加 http://{{ local_image_host }}/ 作为前缀
+        例如：/path/to/images/image.png， 返回 http://{{ local_image_host }}/path/to/images/image.png
+        {% endif %}
         """
 
 def get_qa_strategy(strategy_name: str) -> QAConversationStrategy:


### PR DESCRIPTION
- Introduce `--enable_local_image_host` CLI argument in `auto_coder_rag.py`
- Add `local_image_host` optional field to `AutoCoderArgs` in `common/__init__.py`
- Implement image serving endpoint in `rag/api_server.py`
- Update QA conversation strategies to handle local image paths with optional host prefix
- Support serving image files with proper MIME type and path handling