### PR TITLE
Update image serving endpoint with async file reading and static path…

### DIFF
--- a/src/autocoder/rag/qa_conversation_strategy.py
+++ b/src/autocoder/rag/qa_conversation_strategy.py
@@ -63,8 +63,8 @@ class MultiRoundStrategy(QAConversationStrategy):
         {% if local_image_host %}
         4. 图片路径处理
         - 图片地址需返回绝对路径, 
-        - 为请求图片资源 需增加 http://{{ local_image_host }}/ 作为前缀
-        例如：/path/to/images/image.png， 返回 http://{{ local_image_host }}/path/to/images/image.png
+        - 为请求图片资源 需增加 http://{{ local_image_host }}/static/ 作为前缀
+        例如：/path/to/images/image.png， 返回 http://{{ local_image_host }}/static/path/to/images/image.png
         {% endif %}
         """
 
@@ -114,8 +114,8 @@ class SingleRoundStrategy(QAConversationStrategy):
         {% if local_image_host %}
         4. 图片路径处理
         - 图片地址需返回绝对路径, 
-        - 为请求图片资源 需增加 http://{{ local_image_host }}/ 作为前缀
-        例如：/path/to/images/image.png， 返回 http://{{ local_image_host }}/path/to/images/image.png
+        - 为请求图片资源 需增加 http://{{ local_image_host }}/static/ 作为前缀
+        例如：/path/to/images/image.png， 返回 http://{{ local_image_host }}/static/path/to/images/image.png
         {% endif %}
         """
 


### PR DESCRIPTION
修改如下

-  在api_server.py中使用aiofiles实现文件的异步读写
- 将serve_image移动到最后，这样子按照匹配顺序，会在最后考虑图片资源的请求
- 将 `/{full_path:path}`替换成， `/static/{full_path:path}`, 明确资源的位置，仅匹配静态资源
- 修改图片路径处理的prompt，要求输出结果增加 static。

在R1模型下，可以正确添加static的前缀

![image](https://github.com/user-attachments/assets/e01868fc-caaf-426a-83be-05e44ab9a21d)
![image](https://github.com/user-attachments/assets/9659a4cb-96e8-46e3-8d4f-5a0f4c43cb9d)
