### PR TITLE
静态文件服务安全加固与Nginx集成支持

### DIFF
--- a/src/autocoder/auto_coder_rag.py
+++ b/src/autocoder/auto_coder_rag.py
@@ -313,7 +313,12 @@ def main(input_args: Optional[List[str]] = None):
         "--max_static_path_length", 
         type=int,
         default=3000,
-        help="Maximum length allowed for static file paths"
+        help="Maximum length allowed for static file paths (larger value to better support Chinese characters)"
+    )
+    serve_parser.add_argument(
+        "--enable_nginx_x_accel",
+        action="store_true",
+        help="Enable Nginx X-Accel-Redirect for static file serving when behind Nginx"
     )
     serve_parser.add_argument(
         "--disable_auto_window",

--- a/src/autocoder/auto_coder_rag.py
+++ b/src/autocoder/auto_coder_rag.py
@@ -289,7 +289,11 @@ def main(input_args: Optional[List[str]] = None):
     serve_parser.add_argument("--ssl_keyfile", default="", help="")
     serve_parser.add_argument("--ssl_certfile", default="", help="")
     serve_parser.add_argument("--response_role", default="assistant", help="")
-    serve_parser.add_argument("--doc_dir", default="", help="")
+    serve_parser.add_argument(
+        "--doc_dir", 
+        default="", 
+        help="Document directory path, also used as the root directory for serving static files"
+    )
     serve_parser.add_argument("--enable_local_image_host", action="store_true", help=" enable local image host for local Chat app")
     serve_parser.add_argument("--tokenizer_path", default=tokenizer_path, help="")
     serve_parser.add_argument(
@@ -305,7 +309,12 @@ def main(input_args: Optional[List[str]] = None):
         action="store_true",
         help="Monitor mode for the doc update",
     )
-
+    serve_parser.add_argument(
+        "--max_static_path_length", 
+        type=int,
+        default=3000,
+        help="Maximum length allowed for static file paths"
+    )
     serve_parser.add_argument(
         "--disable_auto_window",
         action="store_true",

--- a/src/autocoder/command_args.py
+++ b/src/autocoder/command_args.py
@@ -433,7 +433,11 @@ def parse_args(input_args: Optional[List[str]] = None) -> AutoCoderArgs:
     doc_serve_parse.add_argument("--ssl_certfile", default="", help="")
     doc_serve_parse.add_argument(
         "--response_role", default="assistant", help="")
-    doc_serve_parse.add_argument("--doc_dir", default="", help="")
+    doc_serve_parse.add_argument(
+        "--doc_dir", 
+        default="", 
+        help="Document directory path, also used as the root directory for serving static files"
+    )
     doc_serve_parse.add_argument("--tokenizer_path", default="", help="")
     doc_serve_parse.add_argument(
         "--collections", default="", help="Collection name for indexing"
@@ -452,6 +456,12 @@ def parse_args(input_args: Optional[List[str]] = None) -> AutoCoderArgs:
         "--monitor_mode",
         action="store_true",
         help="Monitor mode for the doc update",
+    )
+    doc_serve_parse.add_argument(
+        "--max_static_path_length", 
+        type=int,
+        default=1000, 
+        help="Maximum length allowed for static file paths"
     )
 
     agent_parser = subparsers.add_parser("agent", help="Run an agent")

--- a/src/autocoder/rag/api_server.py
+++ b/src/autocoder/rag/api_server.py
@@ -49,6 +49,8 @@ TIMEOUT_KEEP_ALIVE = 5  # seconds
 # timeout in 10 minutes. Streaming can take longer than 3 min
 TIMEOUT = float(os.environ.get("BYZERLLM_APISERVER_HTTP_TIMEOUT", 600))
 
+# Static file serving security settings
+
 router_app = FastAPI()
 
 
@@ -178,46 +180,37 @@ async def embed(body: EmbeddingCompletionRequest):
     )
 
 @router_app.get("/static/{full_path:path}")
-async def serve_image(full_path: str, request: Request):
+async def serve_static_file(full_path: str, request: Request):
     
-    allowed_file_type = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp']
-    
-    if any(full_path.endswith(ext) for ext in allowed_file_type):
-        try:
-            # 获取文件的完整路径，并进行URL解码
-            file_path = unquote(full_path)
-            # 使用 os.path.normpath 来标准化路径，自动处理不同操作系统的路径分隔符
-            file_path = os.path.normpath(file_path)
-            if not os.path.isabs(file_path):
-                file_path = os.path.join("/", file_path)
+    try:
+        # 路径安全检查已经在中间件中完成
+        # 直接使用规范化的路径
+        file_path = os.path.join("/", os.path.normpath(unquote(full_path)))
+        
+        # 检查文件是否存在
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File not found: {file_path}")
             
-            # 检查文件是否存在
-            if not os.path.exists(file_path):
-                raise FileNotFoundError(f"File not found: {file_path}")
-                
-            # 异步读取文件内容
-            async with aiofiles.open(file_path, "rb") as f:
-                content = await f.read()
+        # 异步读取文件内容
+        async with aiofiles.open(file_path, "rb") as f:
+            content = await f.read()
+        
+        # 获取文件的 MIME 类型
+        content_type = mimetypes.guess_type(file_path)[0]
+        if not content_type:
+            content_type = "application/octet-stream"
             
-            # 获取文件的 MIME 类型
-            content_type = mimetypes.guess_type(file_path)[0]
-            if not content_type:
-                content_type = "application/octet-stream"
-                
-            # 返回文件内容
-            return Response(content=content, media_type=content_type)
-        except FileNotFoundError as e:
-            logger.error(f"Image not found: {str(e)}")
-            raise HTTPException(status_code=404, detail=f"Image not found: {str(e)}")
-        except PermissionError as e:
-            logger.error(f"Permission denied: {str(e)}")
-            raise HTTPException(status_code=403, detail=f"Permission denied: {str(e)}")
-        except Exception as e:
-            logger.error(f"Error serving image: {str(e)}")
-            raise HTTPException(status_code=500, detail=f"Error serving image: {str(e)}")
-    
-    # 如果路径中没有图片, 返回 404
-    raise HTTPException(status_code=404, detail="Only images are supported")
+        # 返回文件内容
+        return Response(content=content, media_type=content_type)
+    except FileNotFoundError as e:
+        logger.error(f"File not found: {str(e)}")
+        raise HTTPException(status_code=404, detail=f"File not found: {str(e)}")
+    except PermissionError as e:
+        logger.error(f"Permission denied: {str(e)}")
+        raise HTTPException(status_code=403, detail=f"Permission denied: {str(e)}")
+    except Exception as e:
+        logger.error(f"Error serving file: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Error serving file: {str(e)}")
 
 class ServerArgs(BaseModel):
     host: str = None
@@ -234,14 +227,32 @@ class ServerArgs(BaseModel):
     response_role: str = "assistant"
     ssl_keyfile: str = None
     ssl_certfile: str = None 
-    doc_dir: str = "" 
-    tokenizer_path: Optional[str] = None     
+    doc_dir: str = ""  # Document directory path, also used as the root directory for serving static files
+    tokenizer_path: Optional[str] = None
+    max_static_path_length: int = int(os.environ.get("BYZERLLM_MAX_STATIC_PATH_LENGTH", 3000))  # Maximum length allowed for static file paths (larger value to better support Chinese characters)
 
 def serve(llm:ByzerLLM, args: ServerArgs):
     
     logger.info(f"ByzerLLM API server version {version}")
     logger.info(f"args: {args}")
 
+    # 设置静态文件路径长度限制
+    max_path_length = args.max_static_path_length
+    logger.info(f"Maximum static file path length: {max_path_length}")
+    
+    # 确定允许访问的静态文件目录
+    # 优先级：1. 环境变量 BYZERLLM_ALLOWED_STATIC_DIR
+    #        2. 命令行参数 doc_dir
+    #        3. 默认值 "/tmp"
+    allowed_static_dir = os.environ.get("BYZERLLM_ALLOWED_STATIC_DIR")
+    if not allowed_static_dir and args.doc_dir:
+        allowed_static_dir = args.doc_dir
+    if not allowed_static_dir:
+        allowed_static_dir = "/tmp"
+    
+    allowed_static_abs = os.path.abspath(allowed_static_dir)
+    logger.info(f"Static files root directory: {allowed_static_abs}")
+    
     router_app.add_middleware(
         CORSMiddleware,
         allow_origins=args.allowed_origins,
@@ -249,6 +260,47 @@ def serve(llm:ByzerLLM, args: ServerArgs):
         allow_methods=args.allowed_methods,
         allow_headers=args.allowed_headers,
     )
+    
+    # Add static file security middleware
+    @router_app.middleware("http")
+    async def static_file_security(request: Request, call_next):
+        # Only apply to static routes
+        if request.url.path.startswith("/static/"):
+            # Extract the full_path from the URL
+            path_parts = request.url.path.split("/static/", 1)
+            if len(path_parts) > 1:
+                full_path = path_parts[1]
+                
+                # Check path length
+                if len(full_path) > max_path_length:
+                    logger.warning(f"Path too long: {len(full_path)} > {max_path_length}")
+                    return JSONResponse(
+                        content={"error": "Path too long"},
+                        status_code=401
+                    )
+                
+                # Add warning when path length approaches the limit (80% of max)
+                if len(full_path) > (max_path_length * 0.8):
+                    logger.warning(f"Path length approaching limit: {len(full_path)} is {(len(full_path) / max_path_length * 100):.1f}% of max ({max_path_length})")
+                
+                # Decode and normalize path
+                decoded_path = unquote(full_path)
+                normalized_path = os.path.normpath(decoded_path)
+                
+                # Check if path is in allowed directory
+                abs_path = os.path.abspath(os.path.join("/", normalized_path))
+                
+                # 使用预先计算好的allowed_static_abs
+                is_allowed = abs_path.startswith(allowed_static_abs)
+                
+                if not is_allowed:
+                    logger.warning(f"Unauthorized path access: {abs_path}")
+                    return JSONResponse(
+                        content={"error": "Unauthorized path"},
+                        status_code=401
+                    )
+        
+        return await call_next(request)
     
     if token := os.environ.get("BYZERLLM_API_KEY") or args.api_key:
 


### PR DESCRIPTION
# 静态文件服务安全加固与Nginx集成支持

## 变更摘要

本次PR主要对API服务器的静态文件处理功能进行了安全加固，同时增加了与Nginx反向代理集成的支持，提升了在生产环境下的性能和灵活性。

## 主要变更

### 1. 静态文件限定在特定目录下(默认是--doc-dir下的子目录或文件）

- 可以定义BYZERLLM_ALLOWED_STATIC_DIR环境变量来定义不同于doc_dir的static根目录

### 2. 静态文件路径长度限定

- 对路径进行长度限制，默认限制3000， --max_static_path_length 命令行选项或 BYZERLLM_MAX_STATIC_PATH_LENGTH 环境变量，建议保持默认值
- 增加了路径长度接近限制时(80%)的警告日志，有助于提前发现潜在问题

### 3. 增加Nginx X-Accel-Redirect支持

- 添加了`enable_nginx_x_accel`选项，当API服务器运行在Nginx反向代理后方时，可启用X-Accel-Redirect功能
- 静态文件处理函数现在可以返回特殊的X-Accel-Redirect头部，让Nginx直接提供文件，无需通过应用服务器
- 在`auto_coder_rag.py`中添加了`--enable_nginx_x_accel`命令行选项，允许通过命令行开启此功能



