### PR TITLE
Fix file retrieval logic to skip files with names starting with ~$

### DIFF
--- a/src/autocoder/rag/cache/simple_cache.py
+++ b/src/autocoder/rag/cache/simple_cache.py
@@ -313,6 +313,9 @@ class AutoCoderRAGAsyncUpdateQueue(BaseCacheManager):
                 ):
                     continue
 
+                if file.startswith("~$"):
+                    continue
+
                 file_path = os.path.join(root, file)
                 relative_path = os.path.relpath(file_path, self.path)
                 modify_time = os.path.getmtime(file_path)


### PR DESCRIPTION
Optimize file retrieval logic to skip files with names starting with `~$` to avoid `PermissionError`.

* Add a check in the `get_all_files` method in `src/autocoder/rag/cache/simple_cache.py` to skip files with names starting with `~$`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/allwefantasy/auto-coder?shareId=XXXX-XXXX-XXXX-XXXX).